### PR TITLE
Interleave timing tests for greater reliability

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,2 @@
 ColorVectorSpace
-BenchmarkTools
-JLD
 OffsetArrays


### PR DESCRIPTION
On julia 0.6-dev, inlining is on and so the benchmark tests run. On Travis they seem a bit flaky. It's possible we'll have to adjust the tolerances, but perhaps the key thing is to make them more consistent. One possible way to do that would be to interleave trials of two tests that we are comparing; that might normalize for changes in server load over time better than doing the two tests in separate blocks. There's no way to be sure this will help, but it seems worth a shot.
