### PR TITLE
Add mapping functions

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, ImageCore
 makedocs(modules  = [ImageCore],
          format   = Documenter.Formats.HTML,
          sitename = "ImageCore",
-         pages    = ["index.md", "views.md", "traits.md", "reference.md"])
+         pages    = ["index.md", "views.md", "map.md", "traits.md", "reference.md"])
 
 deploydocs(repo   = "github.com/JuliaImages/ImageCore.jl.git",
            julia  = "0.5",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,9 @@ ImageCore is the lowest-level component of the system of packages
 designed to support image processing and computer vision. Its main
 role is to simplify "conversions" between different image
 representations through different "view" types, and to provide some
-useful low-level "traits" that simplify the writing of algorithms.
+useful low-level functions (including "traits") that simplify image
+display, input/output, and the writing of algorithms.
 
 ```@contents
-Pages = ["views.md", "traits.md", "reference.md"]
+Pages = ["views.md", "map.md", "traits.md", "reference.md"]
 ```

--- a/docs/src/map.md
+++ b/docs/src/map.md
@@ -1,0 +1,107 @@
+# Lazy transformation of values
+
+In image display and input/output, it is sometimes necessary to
+transform the value (or the type) of individual pixels.  For example,
+if you want to view an image with an unconventional range (e.g., -1000
+to 1000, for which the normal range 0=black to 1=white will not be
+very useful), then those values might need to be transformed before
+display. Likewise, if try to save an image to disk that contains some
+out-of-range or NaN values, you are likely to experience an error
+unless the values are put in a range that makes sense for the specific
+file format.
+
+There are several approaches to handling this problem. One is to
+compute a new image with scaled values, and for many users this may be
+the simplest option.  However, particularly with large images (or
+movies) this can present a performance problem.  In such cases, it's
+better to separate the concept of the "map" (transformation) function
+from the image (array) itself. (Here it's worth mentioning the
+[MappedArrays](https://github.com/JuliaArrays/MappedArrays.jl)
+package, which allows you to express lazy transformations on values
+for an entire array.)
+
+ImageCore contains several such transformation functions that are
+frequently useful when working with images. Some of these functions
+operate directly on values:
+
+- [`clamp01`](@ref)
+- [`clamp01nan`](@ref)
+
+These two functions force the returned value to lie between 0 and 1,
+or each color channel to lie between 0 and 1 for color
+images. (`clamp01nan` forces `NaN` to 0, whereas `clamp01` does not
+handle `NaN`.)
+
+A simple application of these functions is in saving images, where you
+may have some out-of-range values but don't care if they get
+truncated:
+
+```julia
+img01 = clamp01nan.(img)
+```
+
+`img01` is safe to save to an image file, whereas trying to save `img`
+might possibly result in an error (depending on the contents of
+`img`).
+
+Other functions require parameters:
+
+- [`scaleminmax`](@ref)
+- [`scalesigned`](@ref)
+- [`colorsigned`](@ref)
+
+These return a function rather than a value; that function can then
+be applied to pixels of the image.  For example:
+
+```julia
+julia> f = scaleminmax(-10, 10)
+(::#9) (generic function with 1 method)
+
+julia> f(10)
+1.0
+
+julia> f(-10)
+0.0
+
+julia> f(5)
+0.75
+```
+
+It's worth noting that you can combine these: for example, you can
+combine `scalesigned` and `colorsigned` to map real values to linear
+colormaps. For example, suppose we want to visualize some data,
+mapping negative values to green hues and positive values to magenta
+hues. Let's say the negative values are a bit more compressed, so
+we're going to map -5 to pure green and +20 to pure magenta. We can
+achieve this easily with the following:
+
+```julia
+julia> sc = scalesigned(-5, 0, 20)  # maps [-5, 0, 20] -> [-1, 0, 1]
+(::#15) (generic function with 1 method)
+
+julia> col = colorsigned()          # maps -1 -> green, +1->magenta
+(::#17) (generic function with 1 method)
+
+julia> f = x->col(sc(x))            # combine the two
+(::#1) (generic function with 1 method)
+
+julia> f(-5)
+RGB{U8}(0.0,1.0,0.0)
+
+julia> f(20)
+RGB{U8}(1.0,0.0,1.0)
+
+julia> f(0)
+RGB{U8}(1.0,1.0,1.0)
+
+julia> f(10)
+RGB{U8}(1.0,0.502,1.0)
+```
+
+Finally, [`takemap`](@ref) exists to automatically set the parameters of
+certain functions from the image itself.  For example,
+
+    takemap(scaleminmax, A)
+
+will return a function that scales the minimum value of `A` to 0 and
+the maximum value of `A` to 1.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -19,6 +19,17 @@ ufixedview
 permuteddimsview
 ```
 
+## List of value-transformations (map functions)
+
+```@docs
+clamp01
+clamp01nan
+scaleminmax
+scalesigned
+colorsigned
+takemap
+```
+
 ## List of traits
 
 ```@docs

--- a/docs/src/traits.md
+++ b/docs/src/traits.md
@@ -22,7 +22,7 @@ julia> pixelspacing(img)
 
 `pixelspacing` returns the spacing between adjacent pixels along each
 axis. Using ImagesAxes, you can even use physical units to encode this
-information, for example for use in microscopy or biomedical imaging.
+information, which might be important for microscopy or biomedical imaging.
 
 ```@meta
 DocTestSetup = quote
@@ -30,6 +30,8 @@ DocTestSetup = quote
     img = rand(RGB{U8}, 680, 480);
 end
 ```
+
+Another simple trait is `coords_spatial`:
 
 ```julia
 julia> coords_spatial(img)

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -10,6 +10,9 @@ using Base: tail, @pure, Indices
 import FixedPointNumbers: ufixed8, ufixed10, ufixed12, ufixed14, ufixed16
 import Graphics: width, height
 
+typealias AbstractGray{T} Color{T,1}
+typealias RealLike Union{Real,AbstractGray}
+
 export
     ## Types
     ChannelView,
@@ -32,6 +35,13 @@ export
     ufixed14,
     ufixed16,
     u16,
+    # mapping values
+    clamp01,
+    clamp01nan,
+    colorsigned,
+    scaleminmax,
+    scalesigned,
+    takemap,
     # traits
     assert_timedim_last,
     coords_spatial,
@@ -48,6 +58,7 @@ export
 include("colorchannels.jl")
 include("convert_reinterpret.jl")
 include("traits.jl")
+include("map.jl")
 include("functions.jl")
 include("deprecated.jl")
 

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -97,17 +97,6 @@ end
 
 ## ColorView
 
-immutable ColorView{C<:Colorant,N,A<:AbstractArray} <: AbstractArray{C,N}
-    parent::A
-
-    function ColorView{T<:Number}(parent::AbstractArray{T})
-        n = length(colorviewsize(C, parent))
-        n == N || throw(DimensionMismatch("for an $N-dimensional ColorView with color type $C, input dimensionality should be $n instead of $(ndims(parent))"))
-        checkdim1(C, size(parent))
-        new(parent)
-    end
-end
-
 """
     ColorView{C}(A)
 
@@ -125,6 +114,17 @@ are interpreted in constructor-argument order, not memory order (see
 
 The opposite transformation is implemented by `ChannelView`.
 """
+immutable ColorView{C<:Colorant,N,A<:AbstractArray} <: AbstractArray{C,N}
+    parent::A
+
+    function ColorView{T<:Number}(parent::AbstractArray{T})
+        n = length(colorviewsize(C, parent))
+        n == N || throw(DimensionMismatch("for an $N-dimensional ColorView with color type $C, input dimensionality should be $n instead of $(ndims(parent))"))
+        checkdim1(C, size(parent))
+        new(parent)
+    end
+end
+
 function (::Type{ColorView{C}}){C<:Colorant,T<:Number}(parent::AbstractArray{T})
     # Creating a ColorView in a type-stable fashion requires use of tuples to compute N+1
     _colorview(base_colorant_type(C){T}, parent, colorviewsize(C, parent))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -80,7 +80,7 @@ dimension.
 """
 assert_timedim_last(img::AbstractArray) = nothing
 
-widthheight(img::AbstractArray) = size(img,1), size(img,2)
+widthheight(img::AbstractArray) = size(img,2), size(img,1)
 
 width(img::AbstractArray) = widthheight(img)[1]
 height(img::AbstractArray) = widthheight(img)[2]

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,0 +1,125 @@
+using ImageCore, FixedPointNumbers, Colors, ColorVectorSpace
+using Base.Test
+
+@testset "map" begin
+    @testset "clamp01" begin
+        @test clamp01(0.1) === 0.1
+        @test clamp01(-0.1) === 0.0
+        @test clamp01(0.9) === 0.9
+        @test clamp01(1.1) === 1.0
+        @test clamp01(Inf) === 1.0
+        @test clamp01(-Inf) === 0.0
+        @test isnan(clamp01(NaN))
+        @test clamp01(U8(0.1)) === U8(0.1)
+        @test clamp01(UFixed12(1.2)) === UFixed12(1.0)
+        @test clamp01(Gray(-0.2)) === Gray(0.0)
+        @test clamp01(Gray(0.7)) === Gray(0.7)
+        @test clamp01(Gray(UFixed12(1.2))) === Gray(UFixed12(1.0))
+        @test clamp01(RGB(0.2,-0.2,1.8)) === RGB(0.2,0.0,1.0)
+        A = [-1.2,0.4,800.3]
+        f = takemap(clamp01, A)
+        fA = f.(A)
+        @test eltype(fA) == Float64
+        @test fA == [0, 0.4, 1]
+        f = takemap(clamp01, U8, A)
+        fA = f.(A)
+        @test eltype(fA) == U8
+        @test fA == [U8(0), U8(0.4), U8(1)]
+    end
+
+    @testset "clamp01nan" begin
+        @test clamp01nan(0.1) === 0.1
+        @test clamp01nan(-0.1) === 0.0
+        @test clamp01nan(0.9) === 0.9
+        @test clamp01nan(1.1) === 1.0
+        @test clamp01nan(Inf) === 1.0
+        @test clamp01nan(-Inf) === 0.0
+        @test clamp01nan(NaN) === 0.0
+        @test clamp01nan(U8(0.1)) === U8(0.1)
+        @test clamp01nan(UFixed12(1.2)) === UFixed12(1.0)
+        @test clamp01nan(Gray(-0.2)) === Gray(0.0)
+        @test clamp01nan(Gray(0.7)) === Gray(0.7)
+        @test clamp01nan(Gray(NaN32)) === Gray(0.0f0)
+        @test clamp01nan(Gray(UFixed12(1.2))) === Gray(UFixed12(1.0))
+        @test clamp01nan(RGB(0.2,-0.2,1.8)) === RGB(0.2,0.0,1.0)
+        @test clamp01nan(RGB(0.2,NaN,1.8)) === RGB(0.2,0.0,1.0)
+        A = [-1.2,0.4,-Inf,NaN,Inf,800.3]
+        f = takemap(clamp01nan, A)
+        fA = f.(A)
+        @test eltype(fA) == Float64
+        @test fA == [0, 0.4, 0, 0, 1, 1]
+        f = takemap(clamp01nan, U8, A)
+        fA = f.(A)
+        @test eltype(fA) == U8
+        @test fA == [U8(0), U8(0.4), U8(0), U8(0), U8(1), U8(1)]
+    end
+
+    @testset "scaleminmax" begin
+        A = [0, 1, 100, 1000, 2000, -7]
+        target = map(x->clamp(x, 0, 1), A/1000)
+        for (f, tgt) in ((scaleminmax(0, 1000), target),
+                          (scaleminmax(0, 1000.0), target),
+                          (scaleminmax(U8, 0, 1000), U8.(target)),
+                          (scaleminmax(U8, 0, 1000.0), U8.(target)),
+                          (scaleminmax(Gray, 0, 1000), Gray{Float64}.(target)),
+                          (scaleminmax(Gray{U8}, 0, 1000.0), Gray{U8}.(target)))
+             fA = @inferred(map(f, A))
+            @test fA == tgt
+            @test eltype(fA) == eltype(tgt)
+        end
+        B = A+10
+        f = scaleminmax(10, 1010)
+        @test f.(B) == target
+        A = [0, 1, 100, 1000]
+        target = A/1000
+        for (f, tgt) in ((takemap(scaleminmax, A), target),
+                          (takemap(scaleminmax, U8, A), U8.(target)),
+                          (takemap(scaleminmax, Gray{U8}, A), Gray{U8}.(target)))
+            fA = @inferred(map(f, A))
+            @test fA == tgt
+            @test eltype(fA) == eltype(tgt)
+        end
+        A = [Gray(-0.1),Gray(0.1)]
+        f = scaleminmax(Gray, -0.1, 0.1)
+        @test f.(A) == [Gray(0.0),Gray(1.0)]
+        A = reinterpret(RGB, [0.0 128.0; 255.0 0.0; 0.0 0.0])
+        f = scaleminmax(RGB, 0, 255)
+        @test f.(A) == [RGB(0,1.0,0), RGB(128/255,0,0)]
+        f = scaleminmax(RGB{U8}, 0, 255)
+        @test f.(A) == [RGB(0,1,0), RGB{U8}(128/255,0,0)]
+        f = takemap(scaleminmax, A)
+        @test f.(A) == [RGB(0,1.0,0), RGB(128/255,0,0)]
+        f = takemap(scaleminmax, RGB{U8}, A)
+        @test f.(A) == [RGB(0,1,0), RGB{U8}(128/255,0,0)]
+    end
+
+    @testset "scalesigned" begin
+        A = [-100,1000]
+        target = A/1000
+        for (f, tgt) in ((scalesigned(1000), target),
+                         (scalesigned(-1000, 0, 1000), target),
+                         (scalesigned(-1000, 0, 1000.0), target),
+                         (takemap(scalesigned, A), target))
+            fA = f.(A)
+            @test fA == tgt
+            @test eltype(fA) == eltype(tgt)
+        end
+    end
+
+    @testset "colorsigned" begin
+        g, w, m = colorant"green1", colorant"white", colorant"magenta"
+        for f in (colorsigned(),
+                  colorsigned(g, m),
+                  colorsigned(g, w, m))
+            @test f(-1) == g
+            @test f( 0) == w
+            @test f( 1) == m
+            @test f(-0.5) ≈ mapc(U8, 0.5g+0.5w)
+            @test f( 0.5) ≈ mapc(U8, 0.5w+0.5m)
+            @test f(-0.25) ≈ mapc(U8, 0.25g+0.75w)
+            @test f( 0.75) ≈ mapc(U8, 0.75m+0.25w)
+        end
+    end
+end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("colorchannels.jl")
 include("views.jl")
 include("convert_reinterpret.jl")
 include("traits.jl")
+include("map.jl")
 include("functions.jl")
 include("deprecated.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 module ImageCoreTests
 
+using ImageCore, Base.Test
+
+@test isempty(detect_ambiguities(ImageCore,Base,Core))
+
 include("colorchannels.jl")
 include("views.jl")
 include("convert_reinterpret.jl")
@@ -8,7 +12,6 @@ include("functions.jl")
 include("deprecated.jl")
 
 # run these last
-@test isempty(detect_ambiguities(ImageCore,Base,Core))
 isCI = haskey(ENV, "CI") || get(ENV, "JULIA_PKGEVAL", false)
 if Base.JLOptions().can_inline == 1 && !isCI
     include("benchmarks.jl")  # these fail if inlining is off

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -15,8 +15,8 @@ using Base.Test
         @test size_spatial(B) == (3,5)
         @test indices_spatial(B) == (Base.OneTo(3), Base.OneTo(5))
         assert_timedim_last(B)
-        @test width(B) == 3
-        @test height(B) == 5
+        @test width(B) == 5
+        @test height(B) == 3
     end
 end
 


### PR DESCRIPTION
These functions will replace the whole `MapInfo` machinery in the old Images. This should be more intuitive than the old approach. (The old approach was necessary at the time because we didn't have fast functions-as-arguments.)

Fairly extensively tested and documented (I hope).
