### PR TITLE
Docstring improvements

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,4 +10,3 @@ deploydocs(repo   = "github.com/JuliaImages/ImageCore.jl.git",
            target = "build",
            deps   = nothing,
            make   = nothing)
-#           deps   = Deps.pip("mkdocs", "python-markdown-math"))

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -17,6 +17,7 @@ ColorView
 rawview
 normedview
 permuteddimsview
+StackedView
 ```
 
 ## List of value-transformations (map functions)
@@ -28,6 +29,18 @@ scaleminmax
 scalesigned
 colorsigned
 takemap
+```
+
+## List of storage-type transformations
+
+```@docs
+float32
+float64
+n0f8
+n6f10
+n4f12
+n2f14
+n0f16
 ```
 
 ## List of traits

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -264,7 +264,7 @@ imgC = colorview(RGB, r, zeroarray, b)
 creates an image with `r` in the red chanel, `b` in the blue channel,
 and nothing in the green channel.
 
-See also: StackedView.
+See also: [`StackedView`](@ref).
 """
 function colorview{C<:Colorant}(::Type{C}, gray1, gray2, grays...)
     T = _colorview_type(eltype(C), promote_eleltype_all(gray1, gray2, grays...))

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -115,6 +115,10 @@ function Base.convert{Cdest<:Color1,n,T<:Real}(::Type{Array{Cdest,n}},
     copy!(Array{ccolor(Cdest, Gray{T})}(size(img)), img)
 end
 
+# for docstrings in the operations below
+shortname{T<:FixedPoint}(::Type{T}) = (io = IOBuffer(); FixedPointNumbers.showtype(io, T); takebuf_string(io))
+shortname{T}(::Type{T}) = string(T)
+
 # float32, float64, etc. Used for conversions like
 #     Array{RGB{N0f8}} -> Array{RGB{Float32}},
 # since
@@ -131,7 +135,7 @@ for (fn,T) in (#(:float16, Float16),   # Float16 currently has promotion problem
         ($fn)(n::Number)   = convert(($fn)(typeof(n)), n)
         @deprecate ($fn){C<:Colorant}(A::AbstractArray{C}) ($fn).(A)
         fname = $(Expr(:quote, fn))
-        Tname = $(Expr(:quote, T))
+        Tname = shortname($T)
 @doc """
     $fname.(img)
 

--- a/src/map.jl
+++ b/src/map.jl
@@ -8,7 +8,7 @@ Produce a value `y` that lies between 0 and 1, and equal to `x` when
 numeric values. For colors, this function is applied to each color
 channel separately.
 
-See also: clamp01nan.
+See also: [`clamp01nan`](@ref).
 """
 clamp01(x::Union{N0f8,N0f16}) = x
 clamp01(x::Number) = clamp(x, zero(x), one(x))
@@ -19,7 +19,7 @@ clamp01(c::Colorant) = mapc(clamp01, c)
 
 Similar to `clamp01`, except that any `NaN` values are changed to 0.
 
-See also: clamp01.
+See also: [`clamp01`](@ref).
 """
 clamp01nan(x) = clamp01(x)
 clamp01nan(x::AbstractFloat) = ifelse(isnan(x), zero(x), clamp01(x))
@@ -67,7 +67,7 @@ julia> f(c)
 RGB{Float64}(1.0,0.5019607843137255,0.0)
 ```
 
-See also: `takemap`.
+See also: [`takemap`](@ref).
 """
 scaleminmax{T}(min::T, max::T) = function(x)
     y = clamp(x, min, max)
@@ -110,7 +110,7 @@ Return a function `f` which scales values in the range `[-maxabs,
 maxabs]` (clamping values that lie outside this range) to the range
 `[-1, 1]`.
 
-See also: colorsigned.
+See also: [`colorsigned`](@ref).
 """
 function scalesigned(maxabs::Real)
     maxabs > 0 || throw(ArgumentError("maxabs must be positive, got $maxabs"))
@@ -124,7 +124,7 @@ Return a function `f` which scales values in the range `[min, center]`
 to `[-1,0]` and `[center,max]` to `[0,1]`. Values smaller than
 `min`/`max` get clamped to `min`/`max`, respectively.
 
-See also: colorsigned.
+See also: [`colorsigned`](@ref).
 """
 function scalesigned{T<:Real}(min::T, center::T, max::T)
     min <= center <= max || throw(ArgumentError("values must be ordered, got $min, $center, $max"))
@@ -157,7 +157,7 @@ The default colors are:
 - `colorneg`: green1
 - `colorpos`: magenta
 
-See also: scalesigned.
+See also: [`scalesigned`](@ref).
 """
 colorsigned{C<:Color}(neg::C, center::C, pos::C) = function(x)
     y = clamp(x, -one(x), one(x))

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -23,7 +23,7 @@ the first dimension of `A`. In particular,
 and so on. Combined with `colorview`, this allows one to combine two
 or more grayscale images into a single color image.
 
-See also: colorview.
+See also: [`colorview`](@ref).
 """
 StackedView
 


### PR DESCRIPTION
@vchuravy pointed out that we can add cross-references in the docstrings, and that definitely makes the HTML documentation more friendly (thanks!). I also took the occasion to make a couple of other docstring tweaks.