### PR TITLE
Use "where" syntax for inner constructor on 0.6

### DIFF
--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -19,13 +19,13 @@ else
     struct StackedView{T<:Number,N,A<:Tuple{Vararg{AbstractArray{T}}}} <: AbstractArray{T,N}
         parents::A
 
-        function (::Type{StackedView{T,N,A}}){T,N,A}(parents::A)
+        function StackedView{T,N,A}(parents::A) where {T<:Number,N,A<:Tuple{Vararg{AbstractArray{T}}}}
             inds = indices(parents[1])
             length(inds) == N-1 || throw(DimensionMismatch("component arrays must be of dimension \$(N-1), got \$(length(inds))"))
             for i = 2:length(parents)
                 indices(parents[i]) == inds || throw(DimensionMismatch("all arrays must have the same indices, got \$inds and \$(indices(parents[i]))"))
             end
-            new{T,N,A}(parents)
+            new(parents)
         end
     end
     """)


### PR DESCRIPTION
This fixes an inference failure on recent 0.6 versions.