### PR TITLE
Performance improvements in scaleminmax

### DIFF
--- a/test/map.jl
+++ b/test/map.jl
@@ -63,7 +63,7 @@ using Base.Test
                           (scaleminmax(N0f8, 0, 1000.0), N0f8.(target)),
                           (scaleminmax(Gray, 0, 1000), Gray{Float64}.(target)),
                           (scaleminmax(Gray{N0f8}, 0, 1000.0), Gray{N0f8}.(target)))
-             fA = @inferred(map(f, A))
+            fA = @inferred(map(f, A))
             @test fA == tgt
             @test eltype(fA) == eltype(tgt)
         end


### PR DESCRIPTION
The most important change here is promoting only once; that's a good idea on its own. Moreover, in conjunction with some other changes in inlining (https://github.com/JuliaMath/FixedPointNumbers.jl/pull/80, https://github.com/JuliaGraphics/ColorTypes.jl/pull/75), *without* this PR, performance seems to have been seriously degraded.

Here's the benchmark I'm using
```julia
using ImageCore, FixedPointNumbers, Colors, ColorVectorSpace, FileIO
img = load("/home/tim/.julia/v0.5/ParallelAccelerator/examples/gaussian-blur/../example.jpg");
renderbuf = similar(img, Gray24);
smm = scaleminmax(Gray24, 0.0f0, 1.0f0);

# after warmup
julia> @time map!(smm, renderbuf, img);
```

Previously (before those two PRs):
```julia
julia> @time map!(smm, renderbuf, img);
  0.857138 seconds (4 allocations: 160 bytes)
```
With those two PRs but without this PR:
```julia
julia> @time map!(smm, renderbuf, img);
 12.761968 seconds (558.93 M allocations: 8.329 GB, 5.67% gc time)
```
With those two PRs *and* with this one:
```julia
julia> @time map!(smm, renderbuf, img);
  0.323427 seconds (4 allocations: 160 bytes)
```

The FixedPointNumbers PR is the one that seems "responsible" for the type-instability (it's a julia bug, of course). Only tested on 0.5. Without the FPN PR but with the ColorTypes + this one, I get
```julia
julia> @time map!(smm, renderbuf, img);
  0.481476 seconds (4 allocations: 160 bytes)
```

So it seems best to have them all, but it's a little scary too.
