### PR TITLE
Trait functions should peer inside containing AbstractArrays

### DIFF
--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -191,6 +191,12 @@ Base.@propagate_inbounds function Base.getindex{C<:Color1,N}(A::ColorView{C,N}, 
     @inbounds ret = C(getchannels(P, C, i)[1])
     ret
 end
+Base.@propagate_inbounds function Base.setindex!{C<:Color1}(A::ColorView{C,1}, val::C, i::Int)  # for ambiguity resolution
+    P = parent(A)
+    @boundscheck checkindex(Bool, linearindices(P), i) || Base.throw_boundserror(A, i)
+    setchannels!(P, val, i)
+    val
+end
 Base.@propagate_inbounds function Base.setindex!{C<:Color1,N}(A::ColorView{C,N}, val::C, i::Int)
     P = parent(A)
     @boundscheck checkindex(Bool, linearindices(P), i) || Base.throw_boundserror(A, i)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -7,6 +7,13 @@ ImagesAxes for images with anisotropic spacing or to encode the
 spacing using physical units.
 """
 pixelspacing{T,N}(img::AbstractArray{T,N}) = ntuple(d->1, Val{N})
+# Some of these traits need to work recursively into "container" types
+pixelspacing(img::AbstractMappedArray) = pixelspacing(parent(img))
+pixelspacing(img::OffsetArray) = pixelspacing(parent(img))
+@inline pixelspacing(img::SubArray) =
+    _subarray_filter(pixelspacing(parent(img)), img.indexes...)
+@inline pixelspacing{T,N,perm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) =
+    _getindex_tuple(pixelspacing(parent(img)), perm)
 
 """
     spacedirections(img) -> (axis1, axis2, ...)
@@ -20,6 +27,13 @@ By default this is computed from `pixelspacing`, but you can set this
 manually using ImagesMeta.
 """
 spacedirections(img::AbstractArray) = _spacedirections(pixelspacing(img))
+spacedirections(img::AbstractMappedArray) = spacedirections(parent(img))
+spacedirections(img::OffsetArray) = spacedirections(parent(img))
+@inline spacedirections(img::SubArray) =
+    _subarray_filter(spacedirections(parent(img)), img.indexes...)
+@inline spacedirections{T,N,perm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) =
+    _getindex_tuple(spacedirections(parent(img)), perm)
+
 function _spacedirections{N}(ps::NTuple{N,Any})
     ntuple(i->ntuple(d->d==i ? ps[d] : zero(ps[d]), Val{N}), Val{N})
 end
@@ -41,7 +55,16 @@ Return a tuple listing the spatial dimensions of `img`.
 
 Note that a better strategy may be to use ImagesAxes and take slices along the time axis.
 """
-coords_spatial{T,N}(img::AbstractArray{T,N}) = ntuple(identity, Val{N})
+@inline coords_spatial{T,N}(img::AbstractArray{T,N}) = ntuple(identity, Val{N})
+
+coords_spatial(img::AbstractMappedArray) = coords_spatial(parent(img))
+coords_spatial(img::OffsetArray) = coords_spatial(parent(img))
+@inline coords_spatial(img::SubArray) =
+    _subarray_offset(0, coords_spatial(parent(img)), img.indexes...)
+@inline coords_spatial{T,N,perm,iperm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm}) =
+    _getindex_tuple(coords_spatial(parent(img)), iperm)
+
+
 
 """
     nimages(img)
@@ -50,6 +73,10 @@ Return the number of time-points in the image array. Defaults to
 1. Use ImagesAxes if you want to use an explicit time dimension.
 """
 nimages(img::AbstractArray) = 1
+nimages(img::AbstractMappedArray) = nimages(parent(img))
+nimages(img::OffsetArray) = nimages(parent(img))
+nimages(img::SubArray) = nimages(parent(img))
+nimages(img::Base.PermutedDimsArrays.PermutedDimsArray) = nimages(parent(img))
 
 """
     size_spatial(img)
@@ -59,6 +86,12 @@ image. Defaults to the same as `size`, but using ImagesAxes you can
 mark some axes as being non-spatial.
 """
 size_spatial(img) = size(img)
+size_spatial(img::AbstractMappedArray) = size_spatial(parent(img))
+size_spatial(img::OffsetArray) = size_spatial(parent(img))
+@inline size_spatial(img::SubArray) =
+    _subarray_filter(size_spatial(parent(img)), img.indexes...)
+@inline size_spatial{T,N,perm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) =
+    _getindex_tuple(size_spatial(parent(img)), perm)
 
 """
     indices_spatial(img)
@@ -68,6 +101,11 @@ image. Defaults to the same as `indices`, but using ImagesAxes you can
 mark some axes as being non-spatial.
 """
 indices_spatial(img) = indices(img)
+indices_spatial(img::AbstractMappedArray) = indices_spatial(parent(img))
+@inline indices_spatial(img::SubArray) =
+    _subarray_filter(indices_spatial(parent(img)), img.indexes...)
+@inline indices_spatial{T,N,perm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) =
+    _getindex_tuple(indices_spatial(parent(img)), perm)
 
 #### Utilities for writing "simple algorithms" safely ####
 # If you don't feel like supporting multiple representations, call these
@@ -79,8 +117,37 @@ Throw an error if the image has a time dimension that is not the last
 dimension.
 """
 assert_timedim_last(img::AbstractArray) = nothing
+assert_timedim_last(img::AbstractMappedArray) = assert_timedim_last(parent(img))
+assert_timedim_last(img::OffsetArray) = assert_timedim_last(parent(img))
+assert_timedim_last(img::SubArray) = assert_timedim_last(parent(img))
 
-widthheight(img::AbstractArray) = size(img,2), size(img,1)
+widthheight(img::AbstractArray) = length(indices(img,2)), length(indices(img,1))
 
 width(img::AbstractArray) = widthheight(img)[1]
 height(img::AbstractArray) = widthheight(img)[2]
+
+
+# Traits whose only meaningful definitions occur in ImageAxes, but for
+# which we want nesting behavior
+spatialorder(img::AbstractMappedArray) = spatialorder(parent(img))
+spatialorder(img::OffsetArray) = spatialorder(parent(img))
+@inline spatialorder{T,N,perm}(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) =
+    _getindex_tuple(spatialorder(parent(img)), perm)
+
+# Utilities
+
+@inline _subarray_filter(x, i::Real, inds...) =
+    _subarray_filter(tail(x), inds...)
+@inline _subarray_filter(x, i, inds...) =
+    (x[1], _subarray_filter(tail(x), inds...)...)
+_subarray_filter(x::Tuple{}) = ()
+
+@inline _subarray_offset(off, x, i::Real, inds...) =
+    _subarray_offset(off-1, tail(x), inds...)
+@inline _subarray_offset(off, x, i, inds...) =
+    (x[1]+off, _subarray_offset(off, tail(x), inds...)...)
+_subarray_offset(off, x::Tuple{}) = ()
+
+@inline _getindex_tuple(t::Tuple, inds::Tuple) =
+    (t[inds[1]], _getindex_tuple(t, tail(inds))...)
+_getindex_tuple(t::Tuple, ::Tuple{}) = ()

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,19 +1,31 @@
-using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace
+using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Base.Test
 
 @testset "Image traits" begin
-    for (B,S) in ((rand(UInt16(1):UInt16(20), 3, 5),"Gray"),
-                  (rand(Gray{Float32}, 3, 5),"Gray"),
-                  (rand(RGB{Float16}, 3, 5),"RGB"),
-                  (bitrand(3, 5),"Binary"),
-                  (rand(UInt32, 3, 5),"RGB24"))
+    for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
+                      (rand(Gray{Float32}, 3, 5), false),
+                      (rand(RGB{Float16}, 3, 5), false),
+                      (bitrand(3, 5), false),
+                      (rand(UInt32, 3, 5), false),
+                      (view(rand(3, 2, 5), :, 1, :), false),
+                      (OffsetArray(rand(3, 5), -1:1, -2:2), false),
+                      (permuteddimsview(rand(5, 3), (2, 1)), true),
+                      (mappedarray(identity, permuteddimsview(rand(5, 3), (2, 1))), true))
         @test pixelspacing(B) == (1,1)
-        @test spacedirections(B) == ((1,0),(0,1))
+        if !isa(B, SubArray)
+            @test spacedirections(B) == (swap ? ((0,1),(1,0)) : ((1,0),(0,1)))
+        else
+            @test spacedirections(B) == ((1,0,0), (0,0,1))
+        end
         @test sdims(B) == 2
-        @test coords_spatial(B) == (1,2)
+        @test coords_spatial(B) == (swap ? (2,1) : (1,2))
         @test nimages(B) == 1
         @test size_spatial(B) == (3,5)
-        @test indices_spatial(B) == (Base.OneTo(3), Base.OneTo(5))
+        if isa(B, OffsetArray)
+            @test indices_spatial(B) == (-1:1, -2:2)
+        else
+            @test indices_spatial(B) == (Base.OneTo(3), Base.OneTo(5))
+        end
         assert_timedim_last(B)
         @test width(B) == 5
         @test height(B) == 3


### PR DESCRIPTION
Previously, `M = mappedarray(f, A)` caused the fallback definition of `pixelspacing` to be called for `M` even if `A` had custom pixelspacing. This should probably be viewed as a bug, since `mappedarray` doesn't change the "geometry" of the image.

This PR introduces "nesting" behavior to all the major trait functions. As a consequence, this is both a bugfix and a breaking change, since the return values of trait functions will now be different.
