### PR TITLE
Remove mapc(::Number) definition

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 FixedPointNumbers 0.3.0
-ColorTypes
+ColorTypes 0.4
 Colors
 MappedArrays 0.0.3
 Graphics

--- a/src/map.jl
+++ b/src/map.jl
@@ -107,8 +107,6 @@ function _scaleminmax{C<:Colorant, T<:Real}(::Type{C}, ::Type{Any}, min::T, max:
     end
 end
 
-ColorTypes.mapc(f, x::Number) = f(x)
-
 function takemap{T<:Real}(::typeof(scaleminmax), A::AbstractArray{T})
     min, max = extrema(A)
     scaleminmax(min, max)


### PR DESCRIPTION
This got implemented in ColorTypes, so removing it avoids a warning.