### PR TITLE
Optionally add padding in `colorview(RGB, img1, img2, ...)`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,7 @@ FixedPointNumbers 0.3.0
 ColorTypes 0.4
 Colors
 MappedArrays 0.0.3
+PaddedViews
 Graphics
 ShowItLikeYouBuildIt
 OffsetArrays

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageCore
 
-using Colors, FixedPointNumbers, MappedArrays, Graphics, ShowItLikeYouBuildIt
+using Colors, FixedPointNumbers, MappedArrays, PaddedViews, Graphics, ShowItLikeYouBuildIt
 using OffsetArrays # for show.jl
 using Compat
 using ColorTypes: colorant_string
@@ -29,6 +29,7 @@ export
     permuteddimsview,
     rawview,
     normedview,
+    paddedviews,
     # conversions
 #    float16,
     float32,

--- a/src/show.jl
+++ b/src/show.jl
@@ -74,12 +74,23 @@ function _showarg_type{T,N,AA<:Array}(io::IO, A::OffsetArray{T,N,AA})
     showcoloranttype(io, T)
     print(io, ',', ndims(A), '}')
 end
+function _showarg_type{T,N}(io::IO, A::OffsetArray{T,N})
+    print(io, "OffsetArray{")
+    showcoloranttype(io, T)
+    print(io, ',', ndims(A), ',')
+    _showarg_type(io, parent(A))
+    print(io, '}')
+end
 
 function Base.summary{T<:Union{FixedPoint,Colorant}}(A::OffsetArray{T})
     io = IOBuffer()
     print(io, ShowItLikeYouBuildIt.dimstring(indices(A)), ' ')
     _showarg_type(io, A)
     String(io)
+end
+
+function _showarg_type(io::IO, A)
+    print(io, typeof(A))
 end
 
 function showcoloranttype{C<:Colorant}(io, ::Type{C})

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -159,3 +159,16 @@ firstinds() = error("not all arrays can be zeroarray")
 @inline take_zeros(T, inds, ::ZeroArrayPromise, Bs...) = (ZeroArrayPromise{T}(inds), take_zeros(T, inds, Bs...)...)
 @inline take_zeros(T, inds, A::AbstractArray, Bs...) = (A, take_zeros(T, inds, Bs...)...)
 take_zeros(T, inds) = ()
+
+# Overrides for paddedviews
+function PaddedViews.paddedviews(fillvalue, As::Union{AbstractArray,ZeroArrayPromise}...)
+    inds = PaddedViews.outerinds(As...)
+    map(A->PaddedView(fillvalue, A, inds), As)
+end
+
+(::Type{PaddedViews.PaddedView})(fillvalue, zap::ZeroArrayPromise, indices) = zap
+
+@inline PaddedViews.outerinds(A::ZeroArrayPromise, Bs...) = PaddedViews.outerinds(Bs...)
+@inline PaddedViews.outerinds() = error("must supply at least one array with concrete indices")
+@inline PaddedViews._outerinds(inds, A::ZeroArrayPromise, Bs...) =
+    PaddedViews._outerinds(inds, Bs...)

--- a/test/show.jl
+++ b/test/show.jl
@@ -30,6 +30,9 @@ end
     @test summary(h) == "-1:1×-2:2 OffsetArray{RGB{N0f8},2}"
     i = channelview(h)
     @test summary(i) == "1:3×-1:1×-2:2 ChannelView(::OffsetArray{RGB{N0f8},2}) with element type FixedPointNumbers.Normed{UInt8,8}"
+    c = ChannelView(rand(RGB{N0f8}, 2))
+    o = OffsetArray(c, -1:1, 0:1)
+    @test summary(o) == "-1:1×0:1 OffsetArray{N0f8,2,ImageCore.ChannelView{FixedPointNumbers.Normed{UInt8,8},2,Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},1}}}"
 end
 
 nothing


### PR DESCRIPTION
Now that ImageTransformations is coming along nicely, it would be great to be able to display nice overlays of two images, kinda like what was promised by the red-green overlay in the [documentation](http://juliaimages.github.io/latest/indexing.html). This is a WIP towards the aim of making it convenient to add padding when creating the overlay.

Unfortunately, the strategy I started with here isn't ideal because it's destroying the type-stability of StackedView; more seriously, it's breaking the "pledge" that `StackedView` creates a, well, view. I kinda suspect we need a whole new type, `PaddedStackedView`. For reasons of type-stability this is going to have to be a separately-dispatchable call, perhaps
```julia
colorview(RGB, fillvalue, r, g, b)
```
or something. I would love feedback on the proper API for this.