### PR TITLE
Rework reinterpret to be consistent with Base (fixes #33)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,8 @@ install:
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 
+build: off
+
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -299,8 +299,8 @@ end
                         (ArrayLS(copy(a0)), ColorView))
             @test_throws ErrorException ColorView(a)
             v = ColorView{T}(a)
-            @test isa(colorview(T,a), VT)
-            @test isa(channelview(v), typeof(a))
+            @test isa(@inferred(colorview(T,a)), VT)
+            @test isa(@inferred(channelview(v)), typeof(a))
             @test ndims(v) == 1
             @test size(v) == (2,)
             @test eltype(v) == T{Float64}

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -129,16 +129,12 @@ using Base.Test
         a = RGB{Float64}[RGB(1,1,0)]
         af = reinterpret(Float64, a)
         @test vec(af) == [1.0,1.0,0.0]
-        @test size(af) == (3,1)
-        @test_throws DimensionMismatch reinterpret(Float32, a)
+        @test size(af) == (3,)
+        @test_throws ArgumentError reinterpret(Int128, a)
         anew = reinterpret(RGB, af)
         @test anew == a
-        anew = reinterpret(RGB, vec(af))
-        @test anew[1] == a[1]
-        @test ndims(anew) == 0
         anew = reinterpret(RGB{Float64}, af)
         @test anew == a
-        @test_throws DimensionMismatch reinterpret(RGB{Float32}, af)
         Au8 = rand(0x00:0xff, 3, 5, 4)
         A8 = reinterpret(N0f8, Au8)
         rawrgb8 = reinterpret(RGB, A8)


### PR DESCRIPTION
Thanks to `Base.@pure`, we can fix #33 without destroying inferrability. Vectors now stay Vectors (this is a behavior change, so this is a breaking change).

CC @rdeits. 