### PR TITLE
Move empty-arg outerinds to PaddedViews

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ FixedPointNumbers 0.3.0
 ColorTypes 0.4
 Colors
 MappedArrays 0.0.3
-PaddedViews
+PaddedViews 0.0.2
 Graphics
 ShowItLikeYouBuildIt
 OffsetArrays

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -160,7 +160,7 @@ firstinds() = error("not all arrays can be zeroarray")
 @inline take_zeros(T, inds, A::AbstractArray, Bs...) = (A, take_zeros(T, inds, Bs...)...)
 take_zeros(T, inds) = ()
 
-# Overrides for paddedviews
+# Extensions of PaddedViews
 function PaddedViews.paddedviews(fillvalue, As::Union{AbstractArray,ZeroArrayPromise}...)
     inds = PaddedViews.outerinds(As...)
     map(A->PaddedView(fillvalue, A, inds), As)
@@ -169,6 +169,5 @@ end
 (::Type{PaddedViews.PaddedView})(fillvalue, zap::ZeroArrayPromise, indices) = zap
 
 @inline PaddedViews.outerinds(A::ZeroArrayPromise, Bs...) = PaddedViews.outerinds(Bs...)
-@inline PaddedViews.outerinds() = error("must supply at least one array with concrete indices")
 @inline PaddedViews._outerinds(inds, A::ZeroArrayPromise, Bs...) =
     PaddedViews._outerinds(inds, Bs...)


### PR DESCRIPTION
The complement of https://github.com/JuliaArrays/PaddedViews.jl/pull/3/commits/1a0ac2a262f589b149326eec4dc22d770e4f737f