### PR TITLE
Fix alignment issues with reinterpret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6-
 FixedPointNumbers 0.3.0
 ColorTypes 0.4
 Colors

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -26,7 +26,7 @@ const NonparametricColors = Union{RGB24,ARGB32,Gray24,AGray32}
 
 ## ChannelView
 
-immutable ChannelView{T,N,A<:AbstractArray} <: AbstractArray{T,N}
+struct ChannelView{T,N,A<:AbstractArray} <: AbstractArray{T,N}
     parent::A
 
     function (::Type{ChannelView{T,N,A}}){T,N,A,C<:Colorant}(parent::AbstractArray{C})
@@ -138,7 +138,7 @@ are interpreted in constructor-argument order, not memory order (see
 The opposite transformation is implemented by
 [`ChannelView`](@ref). See also [`colorview`](@ref).
 """
-immutable ColorView{C<:Colorant,N,A<:AbstractArray} <: AbstractArray{C,N}
+struct ColorView{C<:Colorant,N,A<:AbstractArray} <: AbstractArray{C,N}
     parent::A
 
     function (::Type{ColorView{C,N,A}}){C,N,A,T<:Number}(parent::AbstractArray{T})

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -116,10 +116,10 @@ _unsafe_setindex_all!(I, ::Tuple{}, ::Tuple{}) = nothing
 
 
 # When overlaying 2 images, you often might want one color channel to be black
-immutable ZeroArrayPromise{T} end
+struct ZeroArrayPromise{T} end
 const zeroarray = ZeroArrayPromise{Union{}}()
 
-immutable ZeroArray{T,N,R<:AbstractUnitRange} <: AbstractArray{T,N}
+struct ZeroArray{T,N,R<:AbstractUnitRange} <: AbstractArray{T,N}
     inds::NTuple{N,R}
 end
 

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -1,7 +1,7 @@
 using Colors, ImageCore, OffsetArrays, FixedPointNumbers, Base.Test
 using Compat
 
-immutable ArrayLF{T,N} <: AbstractArray{T,N}
+struct ArrayLF{T,N} <: AbstractArray{T,N}
     A::Array{T,N}
 end
 @compat Base.IndexStyle{A<:ArrayLF}(::Type{A}) = IndexLinear()
@@ -9,7 +9,7 @@ Base.size(A::ArrayLF) = size(A.A)
 Base.getindex(A::ArrayLF, i::Int) = A.A[i]
 Base.setindex!(A::ArrayLF, val, i::Int) = A.A[i] = val
 
-immutable ArrayLS{T,N} <: AbstractArray{T,N}
+struct ArrayLS{T,N} <: AbstractArray{T,N}
     A::Array{T,N}
 end
 @compat Base.IndexStyle{A<:ArrayLS}(::Type{A}) = IndexCartesian()

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -107,6 +107,8 @@ end
     a = reshape([RGB(1,0,0)])  # 0-dimensional
     v = channelview(a)
     @test indices(v) === (Base.OneTo(3),)
+    v = ChannelView(a)
+    @test indices(v) === (Base.OneTo(3),)
 end
 
 @testset "Gray+Alpha" begin
@@ -336,7 +338,8 @@ end
     a = rand(ARGB{N0f8}, 5, 5)
     vc = channelview(a)
     @test isa(colorview(ARGB, vc), Array{ARGB{N0f8},2})
-    @test_throws ArgumentError colorview(RGBA, vc)
+    cvc = colorview(RGBA, vc)
+    @test all(cvc .== a)
 end
 
 @testset "Gray+Alpha" begin

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -126,11 +126,11 @@ using Base.Test
     @test isa(a, Vector) && a == [BGRA{N0f8}(0.533,0.267,0.133,0.941)]
     @test reinterpret(UInt32, a) == [0xf0884422]
     @test size(reinterpret(BGRA{N0f8}, rand(UInt32, 5, 5))) == (5,5)
-    @test size(reinterpret(UInt32, rand(BGRA{N0f8}, 5, 5))) == (5,5)
+    @test size(colorview(ARGB32, rand(BGRA{N0f8}, 5, 5))) == (5,5)
     a = reinterpret(BGRA{N0f8}, [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04])
     @test a == [BGRA{N0f8}(0.533,0.267,0.133,0.941), BGRA{N0f8}(0.012, 0.008, 0.004, 0.016)]
     @test reinterpret(UInt8, a) == [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04]
-    @test reinterpret(UInt32, a) == UInt32[0xf0884422,0x04030201]
+    @test colorview(ARGB32, a) == reinterpret(ARGB32, [0xf0884422,0x04030201])
 
     # indeterminate type tests
     a = Array{RGB{AbstractFloat}}(3)


### PR DESCRIPTION
Support `colorview(ARGB32, ::Array{C<:Colorant})`. Fixes #38. CC @yuyichao.
    
This takes another step in the direction of discouraging explicit use of `reinterpret`. This is considerably more careful to check whether the eltype of input arrays matches the eltype of the Colorant before using `reinterpret`, and consequently is more reliable about falling back to `ColorView`. It resolves the alignment issue by avoiding calling `reinterpret`. To fix #38, we also have to introduce the ability to take a `colorview` of an array that already has `Colorant` eltype (which it does via `channelview`).
    
To simplify the code, this uses triangular dispatch, so this also bumps the minimum required version of Julia. Are folks OK with moving on to 0.6? I was hoping to wait until 0.6 was officially released, but it is a pain in the neck to "fake" triangular dispatch.