### PR TITLE
Fix an ambiguity in `convert`. Fixes #40

### DIFF
--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -72,6 +72,8 @@ ccolor_number{CV<:Colorant,T}(::Type{CV}, ::Type{Any}, ::Type{T}) = CV{T} # form
 # rather than requiring
 #    convert(RGB{N0f8}, a)
 # Where possible the raw element type of the source is retained.
+Base.convert{C<:Color1,n}(::Type{Array{C}},   img::Array{C,n}) = img
+Base.convert{C<:Color1,n}(::Type{Array{C,n}}, img::Array{C,n}) = img
 Base.convert{C<:Colorant,n}(::Type{Array{C}},   img::Array{C,n}) = img
 Base.convert{C<:Colorant,n}(::Type{Array{C,n}}, img::Array{C,n}) = img
 

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -205,4 +205,10 @@ end
     @test indices(float32.(a)) == (-1:1,)
 end
 
+@testset "ambiguities" begin
+    # issue #40
+    d = Dict(:a=>1, :b=>2.0)
+    @test isa(Dict(k=>v for (k,v) in d), Dict{Symbol,Real})
+end
+
 nothing


### PR DESCRIPTION
This ambiguity doesn't get detected by `detect_ambiguities` because the actual ambiguity is in `convert(Vector{Union{}}, ::Vector{Union{}})` and we exclude eltype `Union{}` ambiguities from consideration.

See https://github.com/JuliaLang/julia/pull/22322. This is a fix for older versions of Julia.