### PR TITLE
make colorsigned work with coloralpha

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -180,14 +180,14 @@ The default colors are:
 
 See also: [`scalesigned`](@ref).
 """
-colorsigned(neg::C, center::C, pos::C) where {C<:Color} = function(x)
+colorsigned(neg::C, center::C, pos::C) where {C<:Colorant} = function(x)
     y = clamp(x, -one(x), one(x))
     yabs = abs(y)
     C(ifelse(y>0, weighted_color_mean(yabs, pos, center),
                   weighted_color_mean(yabs, neg, center)))
 end
 
-function colorsigned(colorneg::C, colorpos::C) where C<:Color
+function colorsigned(colorneg::C, colorpos::C) where C<:Colorant
     colorsigned(colorneg, C(colorant"white"), colorpos)
 end
 

--- a/test/map.jl
+++ b/test/map.jl
@@ -119,6 +119,25 @@ using Base.Test
             @test f(-0.25) ≈ mapc(N0f8, 0.25g+0.75w)
             @test f( 0.75) ≈ mapc(N0f8, 0.75m+0.25w)
         end
+        g, w, m = RGBA(0.,1.,0.,1.), RGBA(1.,1.,1.,0.), RGBA(1.,0.,1.,1.)
+        f = colorsigned(g, w, m)
+        @test f(-1) == g
+        @test f( 0) == w
+        @test f( 1) == m
+        @test f(-0.5) ≈ RGBA(0.5,1.0,0.5,0.5)
+        @test f(-0.5) ≈ 0.5g+0.5w
+        @test f( 0.5) ≈ 0.5w+0.5m
+        @test f(-0.25) ≈ 0.25g+0.75w
+        @test f( 0.75) ≈ 0.75m+0.25w
+        w = RGBA{Float64}(colorant"white")
+        f = colorsigned(g, m)
+        @test f(-1) == g
+        @test f( 0) == w
+        @test f( 1) == m
+        @test f(-0.5) ≈ 0.5g+0.5w
+        @test f( 0.5) ≈ 0.5w+0.5m
+        @test f(-0.25) ≈ 0.25g+0.75w
+        @test f( 0.75) ≈ 0.75m+0.25w
     end
 end
 


### PR DESCRIPTION
Ran into this yesterday when playing around with https://github.com/JuliaGL/GLVisualize.jl/pull/199. This change allows for code such as:

```julia
julia> g, w, m = RGBA(0.,1.,0.,1.), RGBA(1.,1.,1.,0.), RGBA(1.,0.,1.,1.)
(RGBA{Float64}(0.0,1.0,0.0,1.0), RGBA{Float64}(1.0,1.0,1.0,0.0), RGBA{Float64}(1.0,0.0,1.0,1.0))

julia> f = colorsigned(g,w,m)
(::#23) (generic function with 1 method)

julia> f(-.5)
RGBA{Float64}(0.5,1.0,0.5,0.5)
```

Is there any reason not to allow other `Colorant` than `Color` that I am not considering?