### PR TITLE
Clean up some issues from #50

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -65,6 +65,7 @@ export
     sdims,
     size_spatial,
     spacedirections,
+    spatialorder,
     width,
     widthheight
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -78,7 +78,12 @@ if VERSION < v"0.7.0-DEV.1790"
     end
     function _showarg_type(io::IO, A::Array)
         print(io, "Array{")
-        ColorTypes.showcoloranttype(io, eltype(A))
+        T = eltype(A)
+        if T<:Colorant
+            ColorTypes.colorant_string_with_eltype(io, T)
+        else
+            ColorTypes.showcoloranttype(io, T)
+        end
         print(io, ',', ndims(A), '}')
     end
 
@@ -95,12 +100,20 @@ if VERSION < v"0.7.0-DEV.1790"
     end
     function _showarg_type(io::IO, A::OffsetArray{T,N,AA}) where {T,N,AA<:Array}
         print(io, "OffsetArray{")
-        ColorTypes.showcoloranttype(io, T)
+        if T<:Colorant
+            ColorTypes.colorant_string_with_eltype(io, T)
+        else
+            ColorTypes.showcoloranttype(io, T)
+        end
         print(io, ',', ndims(A), '}')
     end
     function _showarg_type(io::IO, A::OffsetArray{T,N}) where {T,N}
         print(io, "OffsetArray{")
-        ColorTypes.showcoloranttype(io, T)
+        if T<:Colorant
+            ColorTypes.colorant_string_with_eltype(io, T)
+        else
+            ColorTypes.showcoloranttype(io, T)
+        end
         print(io, ',', ndims(A), ',')
         _showarg_type(io, parent(A))
         print(io, '}')

--- a/test/show.jl
+++ b/test/show.jl
@@ -4,22 +4,20 @@ tformat(x...) = join(string.(x), ", ")
 
 const showit_old = VERSION < v"0.7.0-DEV.1790"
 const eltype_string = showit_old ? "element type" : "eltype"
-const rgb_string = showit_old ? "ColorTypes.RGB" : "RGB"
-const n0f8_string = showit_old ? "FixedPointNumbers.Normed{UInt8,8}" : "N0f8"
 
 @testset "show" begin
     rgb32 = rand(RGB{Float32}, 3, 5)
     v = view(rgb32, 2:3, :)
-    @test summary(v) == "2×5 view(::Array{$rgb_string{Float32},2}, 2:3, :) with $eltype_string ColorTypes.RGB{Float32}"
+    @test summary(v) == "2×5 view(::Array{RGB{Float32},2}, 2:3, :) with $eltype_string ColorTypes.RGB{Float32}"
     a = ChannelView(rgb32)
-    @test summary(a) == "3×3×5 ChannelView(::Array{$rgb_string{Float32},2}) with $eltype_string Float32"
+    @test summary(a) == "3×3×5 ChannelView(::Array{RGB{Float32},2}) with $eltype_string Float32"
     num64 = rand(3,5)
     b = ColorView{RGB}(num64)
     @test summary(b) == "5-element ColorView{RGB}(::Array{Float64,2}) with $eltype_string ColorTypes.RGB{Float64}"
     rgb8 = rand(RGB{N0f8}, 3, 5)
     c = rawview(ChannelView(rgb8))
-    @test summary(c) == "3×3×5 rawview(ChannelView(::Array{$rgb_string{$n0f8_string},2})) with $eltype_string UInt8"
-    @test summary(rgb8) == "3×5 Array{$rgb_string{$n0f8_string},2}"
+    @test summary(c) == "3×3×5 rawview(ChannelView(::Array{RGB{N0f8},2})) with $eltype_string UInt8"
+    @test summary(rgb8) == "3×5 Array{RGB{N0f8},2}"
     rand8 = rand(UInt8, 3, 5)
     d = normedview(permuteddimsview(rand8, (2,1)))
     @test summary(d) == "5×3 normedview(N0f8, PermutedDimsArray(::Array{UInt8,2}, $(tformat((2,1))))) with $eltype_string FixedPointNumbers.Normed{UInt8,8}"
@@ -30,9 +28,9 @@ const n0f8_string = showit_old ? "FixedPointNumbers.Normed{UInt8,8}" : "N0f8"
     g = channelview(rgb8)
     @test summary(g) == (showit_old ? "3×3×5 Array{N0f8,3}" : "3×3×5 Array{N0f8,3} with eltype FixedPointNumbers.Normed{UInt8,8}")
     h = OffsetArray(rgb8, -1:1, -2:2)
-    @test summary(h) == (showit_old ? "-1:1×-2:2 OffsetArray{$rgb_string{$n0f8_string},2}" : "OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}} with indices -1:1×-2:2")
+    @test summary(h) == (showit_old ? "-1:1×-2:2 OffsetArray{RGB{N0f8},2}" : "OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}} with indices -1:1×-2:2")
     i = channelview(h)
-    @test summary(i) == (showit_old ? "1:3×-1:1×-2:2 ChannelView(::OffsetArray{$rgb_string{$n0f8_string},2}) with $eltype_string FixedPointNumbers.Normed{UInt8,8}" : "ChannelView(OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2)) with eltype FixedPointNumbers.Normed{UInt8,8} with indices 1:3×-1:1×-2:2")
+    @test summary(i) == (showit_old ? "1:3×-1:1×-2:2 ChannelView(::OffsetArray{RGB{N0f8},2}) with $eltype_string FixedPointNumbers.Normed{UInt8,8}" : "ChannelView(OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2)) with eltype FixedPointNumbers.Normed{UInt8,8} with indices 1:3×-1:1×-2:2")
     c = ChannelView(rand(RGB{N0f8}, 2))
     o = OffsetArray(c, -1:1, 0:1)
     @test summary(o) == (showit_old ? "-1:1×0:1 OffsetArray{N0f8,2,ImageCore.ChannelView{FixedPointNumbers.Normed{UInt8,8},2,Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},1}}}" :  "OffsetArray(ChannelView(::Array{RGB{N0f8},1}), -1:1, 0:1) with eltype FixedPointNumbers.Normed{UInt8,8} with indices -1:1×0:1")


### PR DESCRIPTION
It turns out that some of what I thought were 0.6 vs 0.7 differences in `show` (and tweaked in #50) were just due to [ColorTypes bugs](https://github.com/JuliaGraphics/ColorTypes.jl/pull/101). This restores previous behavior. This also adds an export that was lost due to deletion of `deprecations.jl`.