### PR TITLE
Rewrite for julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+# 0.6.0
+
+## Breaking changes
+
+- Swtich to Julia 0.7
+- Because of changes to Julia's own `reinterpret`, ImageCore now
+  defines and exports `reinterpretc` for reinterpreting
+        numeric arrays <----> colorant arrays (#52)
+- The ColorView and ChannelView types are deleted; their functionality
+  is now handled via `reinterpret` (#52)

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6.0
 FixedPointNumbers 0.3.0
 ColorTypes 0.4
 Colors
-MappedArrays 0.0.3
+MappedArrays 0.2
 PaddedViews 0.0.2
 Graphics
 OffsetArrays

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,9 @@
-julia 0.6.0
+julia 0.7.0-beta.283
 FixedPointNumbers 0.3.0
 ColorTypes 0.4
 Colors
 MappedArrays 0.2
-PaddedViews 0.0.2
+PaddedViews 0.4.1
 Graphics
-OffsetArrays
+OffsetArrays 0.8
 FFTW

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,7 +5,5 @@ Colors
 MappedArrays 0.0.3
 PaddedViews 0.0.2
 Graphics
-ShowItLikeYouBuildIt 0.1
 OffsetArrays
-Compat 0.19
 FFTW

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -2,9 +2,8 @@ __precompile__()
 
 module ImageCore
 
-using Colors, FixedPointNumbers, MappedArrays, PaddedViews, Graphics, ShowItLikeYouBuildIt
+using Colors, FixedPointNumbers, MappedArrays, PaddedViews, Graphics
 using OffsetArrays # for show.jl
-using Compat
 using ColorTypes: colorant_string
 using Colors: Fractional
 
@@ -14,20 +13,25 @@ import Graphics: width, height
 
 # TODO: just use .+
 # See https://github.com/JuliaLang/julia/pull/22932#issuecomment-330711997
-if VERSION < v"0.7.0-DEV.1759"
-    plus(r::AbstractUnitRange, i::Integer) = r + i
-else
-    plus(r::AbstractUnitRange, i::Integer) = broadcast(+, r, i)
-end
+plus(r::AbstractUnitRange, i::Integer) = broadcast(+, r, i)
 plus(a::AbstractArray, i::Integer) = a .+ i
 
 AbstractGray{T} = Color{T,1}
 const RealLike = Union{Real,AbstractGray}
+Color1{T} = Colorant{T,1}
+Color2{T} = Colorant{T,2}
+Color3{T} = Colorant{T,3}
+Color4{T} = Colorant{T,4}
+AColor{N,C,T} = AlphaColor{C,T,N}
+ColorA{N,C,T} = ColorAlpha{C,T,N}
+const NonparametricColors = Union{RGB24,ARGB32,Gray24,AGray32}
+Color1Array{C<:Color1,N} = AbstractArray{C,N}
+# Type that arises from reshape(reinterpret(To, A), sz):
+const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,M,From,P}}
+const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 export
     ## Types
-    ChannelView,
-    ColorView,
     StackedView,
     ## constants
     zeroarray,
@@ -39,6 +43,7 @@ export
     rawview,
     normedview,
     paddedviews,
+    reinterpretc,
     # conversions
 #    float16,
     float32,
@@ -76,6 +81,7 @@ include("traits.jl")
 include("map.jl")
 include("functions.jl")
 include("show.jl")
+include("deprecations.jl")
 
 """
     rawview(img::AbstractArray{FixedPoint})
@@ -117,7 +123,7 @@ permuteddimsview(A, perm) = Base.PermutedDimsArrays.PermutedDimsArray(A, perm)
 # Support transpose
 Base.transpose(a::AbstractMatrix{C}) where {C<:Colorant} = permutedims(a, (2,1))
 function Base.transpose(a::AbstractVector{C}) where C<:Colorant
-    ind = indices(a, 1)
+    ind = axes(a, 1)
     out = similar(Array{C}, (oftype(ind, Base.OneTo(1)), ind))
     outr = reshape(out, ind)
     copy!(outr, a)

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -16,11 +16,10 @@ import Graphics: width, height
 plus(r::AbstractUnitRange, i::Integer) = broadcast(+, r, i)
 plus(a::AbstractArray, i::Integer) = a .+ i
 
-AbstractGray{T} = Color{T,1}
+using ColorTypes: AbstractGray, TransparentGray, Color3, Transparent3
 const RealLike = Union{Real,AbstractGray}
 Color1{T} = Colorant{T,1}
 Color2{T} = Colorant{T,2}
-Color3{T} = Colorant{T,3}
 Color4{T} = Colorant{T,4}
 AColor{N,C,T} = AlphaColor{C,T,N}
 ColorA{N,C,T} = ColorAlpha{C,T,N}
@@ -90,7 +89,7 @@ returns a "view" of `img` where the values are interpreted in terms of
 their raw underlying storage. For example, if `img` is an `Array{N0f8}`,
 the view will act like an `Array{UInt8}`.
 """
-rawview(a::AbstractArray{T}) where {T<:FixedPoint} = mappedarray((reinterpret, y->T(y,0)), a)
+rawview(a::AbstractArray{T}) where {T<:FixedPoint} = mappedarray(reinterpret, y->T(y,0), a)
 rawview(a::Array{T}) where {T<:FixedPoint} = reinterpret(FixedPointNumbers.rawtype(T), a)
 rawview(a::AbstractArray{T}) where {T<:Real} = a
 
@@ -103,7 +102,7 @@ view will act like an `Array{N0f8}`.  Supply `T` if the element
 type of `img` is `UInt16`, to specify whether you want a `N6f10`,
 `N4f12`, `N2f14`, or `N0f16` result.
 """
-normedview(::Type{T}, a::AbstractArray{S}) where {T<:FixedPoint,S<:Unsigned} = mappedarray((y->T(y,0),reinterpret), a)
+normedview(::Type{T}, a::AbstractArray{S}) where {T<:FixedPoint,S<:Unsigned} = mappedarray(y->T(y,0),reinterpret, a)
 normedview(::Type{T}, a::Array{S}) where {T<:FixedPoint,S<:Unsigned} = reinterpret(T, a)
 normedview(::Type{T}, a::AbstractArray{T}) where {T<:Normed} = a
 normedview(a::AbstractArray{UInt8}) = normedview(N0f8, a)

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -105,22 +105,30 @@ _ccolorview(::Type{C}, A::RRArray{T,C}) where {C<:Colorant,T<:Number} =
     parent(parent(A))
 _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:AbstractGray,T<:Number,M} =
     parent(A)
+_ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:RGB,T<:Number,M} =
+    reshape(parent(A), Base.tail(axes(parent(A))))
+_ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:AbstractRGB,T<:Number,M} =
+    _colorview_reorder(C, A)
+_ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:Color,T<:Number,M} =
+    reshape(parent(A), Base.tail(axes(parent(A))))
 _ccolorview(::Type{C}, A::AbstractArray{T}) where {C<:Colorant,T<:Number} =
     __ccolorview(C, A)  # necessary to avoid ambiguities from dispatch on eltype
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:RGB{T}} = reinterpretc(C, A)
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:AbstractRGB} =
-    reinterpretc(C, view(A, dimorder(C), Base.tail(colons(A))...))
+    _colorview_reorder(C, A)
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:Color{T}} = reinterpretc(C, A)
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:ColorAlpha} =
     _colorviewalpha(base_color_type(C), C, eltype(C), A)
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:AlphaColor} =
-    reinterpretc(C, view(A, dimorder(C), Base.tail(colons(A))...))
+    _colorview_reorder(C, A)
 _colorviewalpha(::Type{C}, ::Type{CA}, ::Type{T}, A::AbstractArray{T}) where {C<:RGB,CA,T} =
     reinterpretc(CA, A)
 _colorviewalpha(::Type{C}, ::Type{CA}, ::Type{T}, A::AbstractArray{T}) where {C<:AbstractRGB,CA,T} =
-    reinterpretc(CA, view(A, dimorder(CA), Base.tail(colons(A))...))
+    _colorview_reorder(CA, A)
 _colorviewalpha(::Type{C}, ::Type{CA}, ::Type{T}, A::AbstractArray{T}) where {C<:Color,CA,T} =
     reinterpretc(CA, A)
+
+_colorview_reorder(::Type{C}, A) where C = reinterpretc(C, view(A, dimorder(C), Base.tail(colons(A))...))
 
 colorview(::Type{ARGB32}, A::AbstractArray{BGRA{N0f8}}) = reinterpret(ARGB32, A)
 

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -3,35 +3,43 @@
 @pure samesize(::Type{T}, ::Type{S}) where {T,S} = sizeof(T) == sizeof(S)
 
 ## Color->Color
-function Base.reinterpret(::Type{CV1}, a::Array{CV2,1}) where {CV1<:Colorant,CV2<:Colorant}
-    CV = ccolor(CV1, CV2)
-    l = (length(a)*sizeof(CV2))÷sizeof(CV1)
-    l*sizeof(CV1) == length(a)*sizeof(CV2) || throw(ArgumentError("sizes are incommensurate"))
-    reinterpret(CV, a, (l,))
-end
-function Base.reinterpret(::Type{CV1}, a::Array{CV2}) where {CV1<:Colorant,CV2<:Colorant}
+# function reinterpretc(::Type{CV1}, a::Array{CV2,1}) where {CV1<:Colorant,CV2<:Colorant}
+#     CV = ccolor(CV1, CV2)
+#     l = (length(a)*sizeof(CV2))÷sizeof(CV1)
+#     l*sizeof(CV1) == length(a)*sizeof(CV2) || throw(ArgumentError("sizes are incommensurate"))
+#     reshape(reinterpret(CV, a), (l,))
+# end
+function reinterpretc(::Type{CV1}, a::AbstractArray{CV2}) where {CV1<:Colorant,CV2<:Colorant}
     CV = ccolor(CV1, CV2)
     if samesize(CV, CV2)
-        return reinterpret(CV, a, size(a))
+        return reshape(reinterpret(CV, a), size(a))
     end
     throw(ArgumentError("result shape not specified"))
 end
 
 ## Color->T
-function Base.reinterpret(::Type{T}, a::Array{CV,1}) where {T<:Number,CV<:Colorant}
-    l = (length(a)*sizeof(CV))÷sizeof(T)
-    l*sizeof(T) == length(a)*sizeof(CV) || throw(ArgumentError("sizes are incommensurate"))
-    reinterpret(T, a, (l,))
-end
-function Base.reinterpret(::Type{T}, a::Array{CV}) where {T<:Number,CV<:Colorant}
+# function reinterpretc(::Type{T}, a::Array{CV,1}) where {T<:Number,CV<:Colorant}
+#     l = (length(a)*sizeof(CV))÷sizeof(T)
+#     l*sizeof(T) == length(a)*sizeof(CV) || throw(ArgumentError("sizes are incommensurate"))
+#     reshape(reinterpret(T, a), (l,))
+# end
+function reinterpretc(::Type{T}, a::AbstractArray{CV}) where {T<:Number,CV<:Colorant}
     if samesize(T, CV)
-        return reinterpret(T, a, size(a))
+        return wrapaxes(reinterpret(T, unwrapaxes(a)), a)
     end
     if sizeof(CV) == sizeof(T)*_len(CV)
-        return reinterpret(T, a, (_len(CV), size(a)...))
+        inds = axes(a)
+        return reshape(reinterpret(T, unwrapaxes(a)), (convert(typeof(inds[1]), Base.OneTo(_len(CV))), inds...))
     end
     throw(ArgumentError("result shape not specified"))
 end
+reinterpretc(::Type{T}, a::AbstractArray{CV,0}) where {T<:Number,CV<:Colorant} =
+    reinterpret(T, reshape(a, 1))
+
+unwrapaxes(a) = a
+unwrapaxes(a::OffsetArray) = a.parent
+wrapaxes(a, aref) = a
+wrapaxes(a, aref::OffsetArray) = OffsetArray(a, axes(aref))
 
 _len(::Type{C}) where {C} = _len(C, eltype(C))
 _len(::Type{C}, ::Type{Any}) where {C} = error("indeterminate type")
@@ -39,23 +47,26 @@ _len(::Type{C}, ::Type{T}) where {C,T} = sizeof(C) ÷ sizeof(T)
 
 ## T->Color
 # We have to distinguish two forms of call:
-#   form 1: reinterpret(RGB{N0f8}, img)
-#   form 2: reinterpret(RGB, img)
-function Base.reinterpret(::Type{CV}, a::Array{T,1}) where {CV<:Colorant,T<:Number}
+#   form 1: reinterpretc(RGB{N0f8}, img)
+#   form 2: reinterpretc(RGB, img)
+function reinterpretc(::Type{CV}, a::AbstractArray{T,1}) where {CV<:Colorant,T<:Number}
     CVT = ccolor_number(CV, T)
     l = (length(a)*sizeof(T))÷sizeof(CVT)
     l*sizeof(CVT) == length(a)*sizeof(T) || throw(ArgumentError("sizes are incommensurate"))
-    reinterpret(CVT, a, (l,))
+    reshape(reinterpret(CVT, a), (l,))
 end
-function Base.reinterpret(::Type{CV}, a::Array{T}) where {CV<:Colorant,T<:Number}
+function reinterpretc(::Type{CV}, a::AbstractArray{T}) where {CV<:Colorant,T<:Number}
+    @noinline throwdm(::Type{C}, ind1) where C =
+        throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))
     CVT = ccolor_number(CV, T)
     if samesize(CVT, T)
-        return reinterpret(CVT, a, size(a))
+        return wrapaxes(reinterpret(CVT, unwrapaxes(a)), a)
     end
-    if size(a, 1)*sizeof(T) == sizeof(CVT)
-        return reinterpret(CVT, a, tail(size(a)))
+    inds = axes(a)
+    if inds[1] == Base.OneTo(sizeof(CVT) ÷ sizeof(eltype(CVT)))
+        return reshape(reinterpret(CVT, unwrapaxes(a)), tail(inds))
     end
-    throw(ArgumentError("result shape not specified"))
+    throwdm(CV, inds[1])
 end
 
 # ccolor_number converts form 2 calls to form 1 calls
@@ -84,7 +95,7 @@ end
 
 function Base.convert(::Type{Array{Cdest,n}},
                       img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
-    copy!(Array{ccolor(Cdest, Csrc)}(size(img)), img)
+    copyto!(Array{ccolor(Cdest, Csrc)}(undef, size(img)), img)
 end
 
 function Base.convert(::Type{Array{Cdest}},
@@ -99,17 +110,17 @@ end
 
 function Base.convert(::Type{Array{Cdest,n}},
                       img::BitArray{n}) where {Cdest<:Color1,n}
-    copy!(Array{ccolor(Cdest, Gray{Bool})}(size(img)), img)
+    copyto!(Array{ccolor(Cdest, Gray{Bool})}(undef, size(img)), img)
 end
 
 function Base.convert(::Type{Array{Cdest,n}},
                       img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
-    copy!(Array{ccolor(Cdest, Gray{T})}(size(img)), img)
+    copyto!(Array{ccolor(Cdest, Gray{T})}(undef, size(img)), img)
 end
 
 function Base.convert(::Type{OffsetArray{Cdest,n,A}},
                       img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n, A <:AbstractArray,Csrc<:Colorant}
-    copy!(OffsetArray{ccolor(Cdest, Csrc)}(Compat.axes(img)),img)
+    copyto!(OffsetArray{ccolor(Cdest, Csrc)}(undef, axes(img)),img)
 end
 
 function Base.convert(::Type{OffsetArray{C,n,A}},
@@ -135,7 +146,7 @@ for (fn,T) in (#(:float16, Float16),   # Float16 currently has promotion problem
         ($fn)(::Type{S}) where {S<:Number  } = $T
         ($fn)(c::Colorant) = convert(($fn)(typeof(c)), c)
         ($fn)(n::Number)   = convert(($fn)(typeof(n)), n)
-        @deprecate ($fn){C<:Colorant}(A::AbstractArray{C}) ($fn).(A)
+        @deprecate ($fn)(A::AbstractArray{C}) where {C<:Colorant} ($fn).(A)
         fname = $(Expr(:quote, fn))
         Tname = shortname($T)
 @doc """

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -18,18 +18,13 @@ function reinterpretc(::Type{CV1}, a::AbstractArray{CV2}) where {CV1<:Colorant,C
 end
 
 ## Color->T
-# function reinterpretc(::Type{T}, a::Array{CV,1}) where {T<:Number,CV<:Colorant}
-#     l = (length(a)*sizeof(CV))÷sizeof(T)
-#     l*sizeof(T) == length(a)*sizeof(CV) || throw(ArgumentError("sizes are incommensurate"))
-#     reshape(reinterpret(T, a), (l,))
-# end
 function reinterpretc(::Type{T}, a::AbstractArray{CV}) where {T<:Number,CV<:Colorant}
     if samesize(T, CV)
         return reinterpret(T, a)
     end
     axs = axes(a)
     if sizeof(CV) == sizeof(T)*_len(CV)
-        return reshape(reinterpret(T, a), (convert(typeof(axs[1]), Base.OneTo(_len(CV))), axs...))
+        return reinterpret(T, reshape(a, Base.OneTo(1), axs...))
     end
     throw(ArgumentError("result shape not specified"))
 end
@@ -44,12 +39,6 @@ _len(::Type{C}, ::Type{T}) where {C,T} = sizeof(C) ÷ sizeof(T)
 # We have to distinguish two forms of call:
 #   form 1: reinterpretc(RGB{N0f8}, img)
 #   form 2: reinterpretc(RGB, img)
-function reinterpretc(::Type{CV}, a::AbstractArray{T,1}) where {CV<:Colorant,T<:Number}
-    CVT = ccolor_number(CV, T)
-    l = (length(a)*sizeof(T))÷sizeof(CVT)
-    l*sizeof(CVT) == length(a)*sizeof(T) || throw(ArgumentError("sizes are incommensurate"))
-    reshape(reinterpret(CVT, a), (l,))
-end
 function reinterpretc(::Type{CV}, a::AbstractArray{T}) where {CV<:Colorant,T<:Number}
     @noinline throwdm(::Type{C}, ind1) where C =
         throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -25,21 +25,16 @@ end
 # end
 function reinterpretc(::Type{T}, a::AbstractArray{CV}) where {T<:Number,CV<:Colorant}
     if samesize(T, CV)
-        return wrapaxes(reinterpret(T, unwrapaxes(a)), a)
+        return reinterpret(T, a)
     end
+    axs = axes(a)
     if sizeof(CV) == sizeof(T)*_len(CV)
-        inds = axes(a)
-        return reshape(reinterpret(T, unwrapaxes(a)), (convert(typeof(inds[1]), Base.OneTo(_len(CV))), inds...))
+        return reshape(reinterpret(T, a), (convert(typeof(axs[1]), Base.OneTo(_len(CV))), axs...))
     end
     throw(ArgumentError("result shape not specified"))
 end
 reinterpretc(::Type{T}, a::AbstractArray{CV,0}) where {T<:Number,CV<:Colorant} =
     reinterpret(T, reshape(a, 1))
-
-unwrapaxes(a) = a
-unwrapaxes(a::OffsetArray) = a.parent
-wrapaxes(a, aref) = a
-wrapaxes(a, aref::OffsetArray) = OffsetArray(a, axes(aref))
 
 _len(::Type{C}) where {C} = _len(C, eltype(C))
 _len(::Type{C}, ::Type{Any}) where {C} = error("indeterminate type")
@@ -60,13 +55,13 @@ function reinterpretc(::Type{CV}, a::AbstractArray{T}) where {CV<:Colorant,T<:Nu
         throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))
     CVT = ccolor_number(CV, T)
     if samesize(CVT, T)
-        return wrapaxes(reinterpret(CVT, unwrapaxes(a)), a)
+        return reinterpret(CVT, a)
     end
-    inds = axes(a)
-    if inds[1] == Base.OneTo(sizeof(CVT) ÷ sizeof(eltype(CVT)))
-        return reshape(reinterpret(CVT, unwrapaxes(a)), tail(inds))
+    axs = axes(a)
+    if axs[1] == Base.OneTo(sizeof(CVT) ÷ sizeof(eltype(CVT)))
+        return reshape(reinterpret(CVT, a), tail(axs))
     end
-    throwdm(CV, inds[1])
+    throwdm(CV, axs[1])
 end
 
 # ccolor_number converts form 2 calls to form 1 calls

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,22 @@
+Base.@deprecate_binding ChannelView channelview
+
+export ColorView
+
+struct ColorView{C<:Colorant,N,A<:AbstractArray} <: AbstractArray{C,N}
+    parent::A
+
+    function ColorView{C,N,A}(parent::AbstractArray{T}) where {C,N,A,T<:Number}
+        n = length(colorview_size(C, parent))
+        n == N || throw(DimensionMismatch("for an $N-dimensional ColorView with color type $C, input dimensionality should be $n instead of $(ndims(parent))"))
+        checkdim1(C, axes(parent))
+        Base.depwarn("ColorView{C}(A) is deprecated, use colorview(C, A)", :ColorView)
+        colorview(C, A)
+    end
+end
+
+function ColorView{C}(A::AbstractArray) where C<:Colorant
+    Base.depwarn("ColorView{C}(A) is deprecated, use colorview(C, A)", :ColorView)
+    colorview(C, A)
+end
+
+ColorView(parent::AbstractArray) = error("must specify the colortype, use colorview(C, A)")

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -20,3 +20,5 @@ function ColorView{C}(A::AbstractArray) where C<:Colorant
 end
 
 ColorView(parent::AbstractArray) = error("must specify the colortype, use colorview(C, A)")
+
+Base.@deprecate_binding squeeze1 true

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,132 +1,35 @@
-function ShowItLikeYouBuildIt.showarg(io::IO, cv::ChannelView, toplevel=false)
-    T, P = eltype(cv), parent(cv)
-    print(io, "ChannelView(")
-    showarg(io, P)
-    print(io, ')')
-    toplevel && print(io, " with eltype ", T)
-end
-
-Base.summary(A::ChannelView) = summary_build(A)
-
-function ShowItLikeYouBuildIt.showarg(io::IO, cv::ColorView, toplevel=false)
-    C, P = eltype(cv), parent(cv)
-    print(io, "ColorView{", ColorTypes.colorant_string(C), "}(")
-    showarg(io, P)
-    print(io, ')')
-    toplevel && print(io, " with eltype ", C)
-end
-
-Base.summary(A::ColorView) = summary_build(A)
-
-if VERSION < v"0.7.0-DEV.1790"
-    function ShowItLikeYouBuildIt.showarg(io::IO, A::PermutedDimsArray{T,N,perm}) where {T,N,perm}
-        print(io, "PermutedDimsArray(")
-        showarg(io, parent(A))
-        print(io, ", ", perm, ')')
-    end
-
-    Base.summary(A::PermutedDimsArray) = summary_build(A)
-end
-
 # rawview
 AAFixed{T<:FixedPoint,N} = AbstractArray{T,N}
-function ShowItLikeYouBuildIt.showarg(io::IO, A::MappedArray{T,N,AA,typeof(reinterpret)}, toplevel=false) where {T<:Integer,N,AA<:AAFixed}
+function Base.showarg(io::IO, A::MappedArray{T,N,AA,typeof(reinterpret)}, toplevel=false) where {T<:Integer,N,AA<:AAFixed}
     print(io, "rawview(")
-    showarg(io, parent(A))
+    Base.showarg(io, parent(A), false)
     print(io, ')')
     toplevel && print(io, " with eltype ", T)
 end
-
-Base.summary(A::MappedArray{T,N,AA,typeof(reinterpret)}) where {T<:Integer,N,AA} = summary_build(A)
 
 # normedview
 AAInteger{T<:Integer,N} = AbstractArray{T,N}
-function ShowItLikeYouBuildIt.showarg(io::IO, A::MappedArray{T,N,AA,F,typeof(reinterpret)}, toplevel=false) where {T<:FixedPoint,N,AA<:AAInteger,F}
+function Base.showarg(io::IO, A::MappedArray{T,N,AA,F,typeof(reinterpret)}, toplevel=false) where {T<:FixedPoint,N,AA<:AAInteger,F}
     print(io, "normedview(")
     ColorTypes.showcoloranttype(io, T)
     print(io, ", ")
-    showarg(io, parent(A))
+    Base.showarg(io, parent(A), false)
     print(io, ')')
     toplevel && print(io, " with eltype ", T)
 end
 
-Base.summary(A::MappedArray{T,N,AA,F,typeof(reinterpret)}) where {T<:FixedPoint,N,AA,F} = summary_build(A)
+function Base.showarg(io::IO, r::Base.ReinterpretArray{T}, toplevel) where {T<:Colorant}
+    print(io, "reinterpret(")
+    ColorTypes.colorant_string_with_eltype(io, T)
+    print(io, ", ")
+    Base.showarg(io, parent(r), false)
+    print(io, ')')
+end
 
-if VERSION < v"0.7.0-DEV.1790"
-    # SubArray of Colorant
-    _showindices(io, indices) = print(io, indices)
-    _showindices(io, ::Base.Slice) = print(io, ':')
-    function ShowItLikeYouBuildIt.showarg(io::IO, A::SubArray{T,N}) where {T<:Colorant,N}
-        print(io, "view(")
-        showarg(io, parent(A))
-        print(io, ", ")
-        for (i, indices) in enumerate(A.indexes)
-            _showindices(io, indices)
-            i < length(A.indexes) && print(io, ", ")
-        end
-        print(io, ')')
-    end
-
-    Base.summary(A::SubArray{T,N}) where {T<:Colorant,N} = summary_build(A)
-
-
-    ## Specializations of other containers based on a color or fixed-point eltype
-    # These may be going too far, but let's see how it works out
-    function ShowItLikeYouBuildIt.showarg(io::IO, A::Array{T,N}) where {T<:Union{FixedPoint,Colorant},N}
-        print(io, "::")
-        _showarg_type(io, A)
-    end
-    function _showarg_type(io::IO, A::Array)
-        print(io, "Array{")
-        T = eltype(A)
-        if T<:Colorant
-            ColorTypes.colorant_string_with_eltype(io, T)
-        else
-            ColorTypes.showcoloranttype(io, T)
-        end
-        print(io, ',', ndims(A), '}')
-    end
-
-    function Base.summary(A::Array{T}) where T<:Union{FixedPoint,Colorant}
-        io = IOBuffer()
-        print(io, ShowItLikeYouBuildIt.dimstring(indices(A)), ' ')
-        _showarg_type(io, A)
-        String(io)
-    end
-
-    function ShowItLikeYouBuildIt.showarg(io::IO, A::OffsetArray{T,N,AA}) where {T<:Union{FixedPoint,Colorant},N,AA<:Array}
-        print(io, "::")
-        _showarg_type(io, A)
-    end
-    function _showarg_type(io::IO, A::OffsetArray{T,N,AA}) where {T,N,AA<:Array}
-        print(io, "OffsetArray{")
-        if T<:Colorant
-            ColorTypes.colorant_string_with_eltype(io, T)
-        else
-            ColorTypes.showcoloranttype(io, T)
-        end
-        print(io, ',', ndims(A), '}')
-    end
-    function _showarg_type(io::IO, A::OffsetArray{T,N}) where {T,N}
-        print(io, "OffsetArray{")
-        if T<:Colorant
-            ColorTypes.colorant_string_with_eltype(io, T)
-        else
-            ColorTypes.showcoloranttype(io, T)
-        end
-        print(io, ',', ndims(A), ',')
-        _showarg_type(io, parent(A))
-        print(io, '}')
-    end
-
-    function Base.summary(A::OffsetArray{T}) where T<:Union{FixedPoint,Colorant}
-        io = IOBuffer()
-        print(io, ShowItLikeYouBuildIt.dimstring(indices(A)), ' ')
-        _showarg_type(io, A)
-        String(io)
-    end
-
-    function _showarg_type(io::IO, A)
-        print(io, typeof(A))
-    end
+function Base.showarg(io::IO, r::Base.ReinterpretArray{T}, toplevel) where {T<:FixedPoint}
+    print(io, "reinterpret(")
+    ColorTypes.showcoloranttype(io, T)
+    print(io, ", ")
+    Base.showarg(io, parent(r), false)
+    print(io, ')')
 end

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -2,10 +2,10 @@ struct StackedView{T<:Number,N,A<:Tuple{Vararg{AbstractArray{T}}}} <: AbstractAr
     parents::A
 
     function StackedView{T,N,A}(parents::A) where {T<:Number,N,A<:Tuple{Vararg{AbstractArray{T}}}}
-        inds = indices(parents[1])
+        inds = axes(parents[1])
         length(inds) == N-1 || throw(DimensionMismatch("component arrays must be of dimension \$(N-1), got \$(length(inds))"))
         for i = 2:length(parents)
-            indices(parents[i]) == inds || throw(DimensionMismatch("all arrays must have the same indices, got \$inds and \$(indices(parents[i]))"))
+            axes(parents[i]) == inds || throw(DimensionMismatch("all arrays must have the same indices, got \$inds and \$(axes(parents[i]))"))
         end
         new(parents)
     end
@@ -28,7 +28,7 @@ See also: [`colorview`](@ref).
 StackedView
 
 @inline Base.size(V::StackedView) = (length(V.parents), size(V.parents[1])...)
-@inline Base.indices(V::StackedView) = (Base.OneTo(length(V.parents)), indices(V.parents[1])...)
+@inline Base.axes(V::StackedView) = (Base.OneTo(length(V.parents)), axes(V.parents[1])...)
 
 @inline function Base.getindex(V::StackedView{T,N}, I::Vararg{Int,N}) where {T,N}
     i1, itail = I[1], tail(I)
@@ -105,7 +105,7 @@ end
 ZeroArrayPromise{T}(inds::NTuple{N,R}) where {T,N,R<:AbstractUnitRange} = ZeroArray{T,N,R}(inds)
 Base.eltype(::Type{ZeroArrayPromise{T}}) where {T} = T
 
-Base.indices(A::ZeroArray) = A.inds
+Base.axes(A::ZeroArray) = A.inds
 Base.getindex(A::ZeroArray{T,N}, I::Vararg{Int,N}) where {T,N} = zero(T)
 
 
@@ -131,7 +131,7 @@ end
 _stackedview(::Type{T}, ::Tuple{Vararg{Any,N}}, arrays) where {T,N} = StackedView{T,N,typeof(arrays)}(arrays)
 
 
-@inline firstinds(A::AbstractArray, Bs...) = indices(A)
+@inline firstinds(A::AbstractArray, Bs...) = axes(A)
 @inline firstinds(::ZeroArrayPromise, Bs...) = firstinds(Bs...)
 firstinds() = error("not all arrays can be zeroarray")
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -121,7 +121,7 @@ assert_timedim_last(img::AbstractMappedArray) = assert_timedim_last(parent(img))
 assert_timedim_last(img::OffsetArray) = assert_timedim_last(parent(img))
 assert_timedim_last(img::SubArray) = assert_timedim_last(parent(img))
 
-widthheight(img::AbstractArray) = Base._length(axes(img,2)), Base._length(axes(img,1))
+widthheight(img::AbstractArray) = length(axes(img,2)), length(axes(img,1))
 
 width(img::AbstractArray) = widthheight(img)[1]
 height(img::AbstractArray) = widthheight(img)[2]

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -11,7 +11,7 @@ pixelspacing(img::AbstractArray{T,N}) where {T,N} = ntuple(d->1, Val(N))
 pixelspacing(img::AbstractMappedArray) = pixelspacing(parent(img))
 pixelspacing(img::OffsetArray) = pixelspacing(parent(img))
 @inline pixelspacing(img::SubArray) =
-    _subarray_filter(pixelspacing(parent(img)), img.indexes...)
+    _subarray_filter(pixelspacing(parent(img)), img.indices...)
 @inline pixelspacing(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) where {T,N,perm} =
     _getindex_tuple(pixelspacing(parent(img)), perm)
 
@@ -30,7 +30,7 @@ spacedirections(img::AbstractArray) = _spacedirections(pixelspacing(img))
 spacedirections(img::AbstractMappedArray) = spacedirections(parent(img))
 spacedirections(img::OffsetArray) = spacedirections(parent(img))
 @inline spacedirections(img::SubArray) =
-    _subarray_filter(spacedirections(parent(img)), img.indexes...)
+    _subarray_filter(spacedirections(parent(img)), img.indices...)
 @inline spacedirections(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) where {T,N,perm} =
     _getindex_tuple(spacedirections(parent(img)), perm)
 
@@ -60,7 +60,7 @@ Note that a better strategy may be to use ImagesAxes and take slices along the t
 coords_spatial(img::AbstractMappedArray) = coords_spatial(parent(img))
 coords_spatial(img::OffsetArray) = coords_spatial(parent(img))
 @inline coords_spatial(img::SubArray) =
-    _subarray_offset(0, coords_spatial(parent(img)), img.indexes...)
+    _subarray_offset(0, coords_spatial(parent(img)), img.indices...)
 @inline coords_spatial(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm}) where {T,N,perm,iperm} =
     _getindex_tuple(coords_spatial(parent(img)), iperm)
 
@@ -89,7 +89,7 @@ size_spatial(img) = size(img)
 size_spatial(img::AbstractMappedArray) = size_spatial(parent(img))
 size_spatial(img::OffsetArray) = size_spatial(parent(img))
 @inline size_spatial(img::SubArray) =
-    _subarray_filter(size_spatial(parent(img)), img.indexes...)
+    _subarray_filter(size_spatial(parent(img)), img.indices...)
 @inline size_spatial(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) where {T,N,perm} =
     _getindex_tuple(size_spatial(parent(img)), perm)
 
@@ -100,10 +100,10 @@ Return a tuple with the indices of the spatial dimensions of the
 image. Defaults to the same as `indices`, but using ImagesAxes you can
 mark some axes as being non-spatial.
 """
-indices_spatial(img) = indices(img)
+indices_spatial(img) = axes(img)
 indices_spatial(img::AbstractMappedArray) = indices_spatial(parent(img))
 @inline indices_spatial(img::SubArray) =
-    _subarray_filter(indices_spatial(parent(img)), img.indexes...)
+    _subarray_filter(indices_spatial(parent(img)), img.indices...)
 @inline indices_spatial(img::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm}) where {T,N,perm} =
     _getindex_tuple(indices_spatial(parent(img)), perm)
 
@@ -121,7 +121,7 @@ assert_timedim_last(img::AbstractMappedArray) = assert_timedim_last(parent(img))
 assert_timedim_last(img::OffsetArray) = assert_timedim_last(parent(img))
 assert_timedim_last(img::SubArray) = assert_timedim_last(parent(img))
 
-widthheight(img::AbstractArray) = length(indices(img,2)), length(indices(img,1))
+widthheight(img::AbstractArray) = Base._length(axes(img,2)), Base._length(axes(img,1))
 
 width(img::AbstractArray) = widthheight(img)[1]
 height(img::AbstractArray) = widthheight(img)[2]

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -1,5 +1,4 @@
-using Colors, ImageCore, OffsetArrays, FixedPointNumbers, Base.Test
-using Compat
+using Colors, ImageCore, OffsetArrays, FixedPointNumbers, Test
 
 struct ArrayLF{T,N} <: AbstractArray{T,N}
     A::Array{T,N}
@@ -24,17 +23,16 @@ Base.setindex!(A::ArrayLS{T,N}, val, i::Vararg{Int,N}) where {T,N} = A.A[i...] =
     @test channelview(a) === a
 
     a0 = [Gray(N0f8(0.2)), Gray(N0f8(0.4))]
-    for (a, VT, LI) in ((copy(a0), Array, IndexLinear()),
-                       (ArrayLF(copy(a0)), ChannelView, IndexLinear()),
-                       (ArrayLS(copy(a0)), ChannelView, IndexCartesian()))
-        v = ChannelView(a)
-        @test isa(channelview(a), VT)
-        @test IndexStyle(v) == LI
-        @test isa(colorview(Gray, v), typeof(a))
-        @test ndims(v) == 2 - ImageCore.squeeze1
-        @test size(v) == (ImageCore.squeeze1 ? (2,) : (1, 2))
+    for (a, LI) in ((copy(a0), IndexLinear()),
+                    (ArrayLF(copy(a0)), IndexLinear()),
+                    (ArrayLS(copy(a0)), IndexCartesian()))
+        v = channelview(a)
+        @test @inferred(IndexStyle(v)) == LI
+        @test ndims(v) == 1
+        @test size(v) == (2,)
         @test eltype(v) == N0f8
-        @test parent(v) === a
+        @test colorview(Gray, v) === a
+        @test parent(parent(v)) === a
         @test v[1] == N0f8(0.2)
         @test v[2] == N0f8(0.4)
         @test_throws BoundsError v[0]
@@ -44,32 +42,36 @@ Base.setindex!(A::ArrayLS{T,N}, val, i::Vararg{Int,N}) where {T,N} = A.A[i...] =
         @test_throws BoundsError (v[0] = 0.6)
         @test_throws BoundsError (v[3] = 0.6)
         c = similar(v)
-        @test isa(c, ChannelView{N0f8,1,Array{Gray{N0f8},1}})
+        @test eltype(c) == N0f8 && ndims(c) == 1
         @test length(c) == 2
-        c = similar(v, ImageCore.squeeze1 ? 3 : (1,3))
-        @test isa(c, ChannelView{N0f8,1,Array{Gray{N0f8},1}})
+        c = similar(v, 3)
+        @test eltype(c) == N0f8 && ndims(c) == 1
         @test length(c) == 3
         c = similar(v, Float32)
-        @test isa(c, ChannelView{Float32,1,Array{Gray{Float32},1}})
+        @test eltype(c) == Float32 && ndims(c) == 1
         @test length(c) == 2
-        c = similar(v, Float16, ImageCore.squeeze1 ? (5,5) : (1,5,5))
-        @test isa(c, ChannelView{Float16,2,Array{Gray{Float16},2}})
-        @test size(c) == (ImageCore.squeeze1 ? (5,5) : (1,5,5))
+        c = similar(v, Float16, (5,5))
+        @test eltype(c) == Float16 && ndims(c) == 2
+        @test size(c) == (5,5)
     end
 end
 
 @testset "RGB, HSV, etc" begin
     for T in (RGB, BGR, RGB1, RGB4, HSV, Lab, XYZ)
         a0 = [T(0.1,0.2,0.3), T(0.4, 0.5, 0.6)]
-        for (a, VT) in ((copy(a0), T<:Union{BGR,RGB1,RGB4} ? ChannelView : Array),
-                        (ArrayLS(copy(a0)), ChannelView))
-            v = ChannelView(a)
-            @test isa(channelview(a), VT)
-            @test isa(colorview(T, v), typeof(a))
+        for a in (copy(a0),
+                  ArrayLS(copy(a0)))
+            v = channelview(a)
             @test ndims(v) == 2
             @test size(v) == (3,2)
             @test eltype(v) == Float64
-            @test parent(v) === a
+            if T in (RGB, HSV, Lab, XYZ)
+                @test colorview(T, v) === a
+                @test parent(parent(v)) === a
+            else
+                @test colorview(T, v) == a
+                @test parent(parent(v)) == a
+            end
             @test v[1] == v[1,1] == 0.1
             @test v[2] == v[2,1] == 0.2
             @test v[3] == v[3,1] == 0.3
@@ -89,38 +91,31 @@ end
             @test_throws BoundsError (v[2,0] = 0.7)
             @test_throws BoundsError (v[2,3] = 0.7)
             c = similar(v)
-            @test isa(c, ChannelView{Float64,2,Array{T{Float64},1}})
-            @test size(c) == (3,2)
+            @test size(c) == (3,2) && eltype(c) == Float64
             c = similar(v, (3,4))
-            @test isa(c, ChannelView{Float64,2,Array{T{Float64},1}})
-            @test size(c) == (3,4)
-            @test_throws DimensionMismatch similar(v, (5,4))
+            @test size(c) == (3,4) && eltype(c) == Float64
             c = similar(v, Float32)
-            @test isa(c, ChannelView{Float32,2,Array{T{Float32},1}})
-            @test size(c) == (3,2)
+            @test size(c) == (3,2) && eltype(c) == Float32
             c = similar(v, Float16, (3,5,5))
-            @test isa(c, ChannelView{Float16,3,Array{T{Float16},2}})
-            @test size(c) == (3,5,5)
-            @test_throws DimensionMismatch similar(v, Float16, (2,5,5))
+            @test size(c) == (3,5,5) && eltype(c) == Float16
         end
     end
     a = reshape([RGB(1,0,0)])  # 0-dimensional
     v = channelview(a)
-    @test indices(v) === (Base.OneTo(3),)
-    v = ChannelView(a)
-    @test indices(v) === (Base.OneTo(3),)
+    @test axes(v) === (Base.OneTo(3),)
+    v = channelview(a)
+    @test axes(v) === (Base.OneTo(3),)
 end
 
 @testset "Gray+Alpha" begin
-    for (T,VT) in ((AGray,ChannelView),(GrayA,Array))
+    for T in (AGray, GrayA)
         a = [T(0.1f0,0.2f0), T(0.3f0,0.4f0), T(0.5f0,0.6f0)]
-        v = ChannelView(a)
-        @test isa(channelview(a), VT)
-        @test isa(colorview(T, v), Array)
+        v = channelview(a)
+        @test colorview(T, v) == a
         @test ndims(v) == 2
         @test size(v) == (2,3)
         @test eltype(v) == Float32
-        @test parent(v) === a
+        @test parent(parent(v)) == a
         @test v[1] == v[1,1] == 0.1f0
         @test v[2] == v[2,1] == 0.2f0
         @test v[3] == v[1,2] == 0.3f0
@@ -140,41 +135,36 @@ end
         @test_throws BoundsError (v[2,0] = 0.7)
         @test_throws BoundsError (v[2,4] = 0.7)
         c = similar(v)
-        @test isa(c, ChannelView{Float32,2,Array{T{Float32},1}})
+        @test eltype(c) == Float32
         @test size(c) == (2,3)
         c = similar(v, (2,4))
-        @test isa(c, ChannelView{Float32,2,Array{T{Float32},1}})
+        @test eltype(c) == Float32
         @test size(c) == (2,4)
-        @test_throws DimensionMismatch similar(v, (3,4))
         c = similar(v, Float64)
-        @test isa(c, ChannelView{Float64,2,Array{T{Float64},1}})
+        @test eltype(c) == Float64
         @test size(c) == (2,3)
         c = similar(v, Float16, (2,5,5))
-        @test isa(c, ChannelView{Float16,3,Array{T{Float16},2}})
+        @test eltype(c) == Float16
         @test size(c) == (2,5,5)
-        @test_throws DimensionMismatch similar(v, Float16, (3,5,5))
     end
 end
 
 @testset "Alpha+RGB, HSV, etc" begin
-    for (T, VT) in ((ARGB, ChannelView),
-                    (ABGR, ChannelView),
-                    (AHSV, ChannelView),
-                    (ALab, ChannelView),
-                    (AXYZ, ChannelView),
-                    (RGBA, Array),
-                    (BGRA, ChannelView),
-                    (HSVA, Array),
-                    (LabA, Array),
-                    (XYZA, Array))
+    for T in (ARGB,
+              ABGR,
+              AHSV,
+              ALab,
+              AXYZ,
+              RGBA,
+              BGRA,
+              LabA,
+              XYZA)
         a = [T(0.1,0.2,0.3,0.4), T(0.5,0.6,0.7,0.8)]
-        v = ChannelView(a)
-        @test isa(channelview(a), VT)
-        @test isa(colorview(T, v), Array)
+        v = channelview(a)
         @test ndims(v) == 2
         @test size(v) == (4,2)
         @test eltype(v) == Float64
-        @test parent(v) === a
+        @test parent(parent(v)) == a
         @test v[1] == v[1,1] == 0.1
         @test v[2] == v[2,1] == 0.2
         @test v[3] == v[3,1] == 0.3
@@ -196,29 +186,27 @@ end
         @test_throws BoundsError (v[2,0] = 0.7)
         @test_throws BoundsError (v[2,3] = 0.7)
         c = similar(v)
-        @test isa(c, ChannelView{Float64,2,Array{T{Float64},1}})
+        @test eltype(c) == Float64
         @test size(c) == (4,2)
         c = similar(v, (4,4))
-        @test isa(c, ChannelView{Float64,2,Array{T{Float64},1}})
+        @test eltype(c) == Float64
         @test size(c) == (4,4)
-        @test_throws DimensionMismatch similar(v, (5,4))
         c = similar(v, Float32)
-        @test isa(c, ChannelView{Float32,2,Array{T{Float32},1}})
+        @test eltype(c) == Float32
         @test size(c) == (4,2)
         c = similar(v, Float16, (4,5,5))
-        @test isa(c, ChannelView{Float16,3,Array{T{Float16},2}})
+        @test eltype(c) == Float16
         @test size(c) == (4,5,5)
-        @test_throws DimensionMismatch similar(v, Float16, (3,5,5))
     end
 
     @testset "Non-1 indices" begin
         a = OffsetArray(rand(RGB{N0f8}, 3, 5), -1:1, -2:2)
         v = channelview(a)
-        @test @inferred(indices(v)) === (1:3, -1:1, -2:2)
+        @test @inferred(axes(v)) === (Base.Slice(1:3), Base.Slice(-1:1), Base.Slice(-2:2))
         @test @inferred(v[1,0,0]) === a[0,0].r
         a = OffsetArray(rand(Gray{Float32}, 3, 5), -1:1, -2:2)
         v = channelview(a)
-        @test @inferred(indices(v)) === (-1:1, -2:2)
+        @test @inferred(axes(v)) === (Base.Slice(-1:1), Base.Slice(-2:2))
         @test @inferred(v[0,0]) === gray(a[0,0])
         @test @inferred(v[5]) === gray(a[5])
         v[5] = -1
@@ -231,20 +219,18 @@ end
 @testset "ColorView" begin
 
 @testset "grayscale" begin
-    _a0 = [N0f8(0.2), N0f8(0.4)]
-    a0 = ImageCore.squeeze1 ? _a0 : reshape(_a0, (1, 2))
-    for (a, VT, LI) in ((copy(a0), Array{Gray{N0f8}}, IndexLinear()),
-                        (ArrayLF(copy(a0)), ColorView{Gray{N0f8}}, IndexLinear()),
-                        (ArrayLS(copy(a0)), ColorView{Gray{N0f8}}, IndexCartesian()))
-        @test_throws ErrorException ColorView(a)
-        v = ColorView{Gray}(a)
-        @test isa(colorview(Gray,a), VT)
-        @test IndexStyle(v) == LI
-        @test isa(channelview(v), typeof(a))
+    a0 = [N0f8(0.2), N0f8(0.4)]
+    for (a, LI) in ((copy(a0), IndexLinear()),
+                    (ArrayLF(copy(a0)), IndexLinear()),
+                    (ArrayLS(copy(a0)), IndexCartesian()))
+        @test_throws MethodError colorview(a)
+        v = colorview(Gray, a)
+        @test @inferred(IndexStyle(v)) == LI
         @test ndims(v) == 1
         @test size(v) == (2,)
         @test eltype(v) == Gray{N0f8}
-        @test parent(v) === a
+        @test channelview(v) === a
+        @test parent(parent(v)) === a
         @test v[1] == Gray(N0f8(0.2))
         @test v[2] == Gray(N0f8(0.4))
         @test_throws BoundsError v[0]
@@ -254,35 +240,33 @@ end
         @test_throws BoundsError (v[0] = 0.6)
         @test_throws BoundsError (v[3] = 0.6)
         c = similar(v)
-        @test isa(c, ColorView{Gray{N0f8},1,Array{N0f8,1}})
+        @test eltype(c) == Gray{N0f8} && ndims(c) == 1
         @test length(c) == 2
-        c = similar(v, ImageCore.squeeze1 ? 3 : (1,3))
-        @test isa(c, ColorView{Gray{N0f8},1,Array{N0f8,1}})
+        c = similar(v, 3)
+        @test eltype(c) == Gray{N0f8} && ndims(c) == 1
         @test length(c) == 3
         c = similar(v, Gray{Float32})
-        @test isa(c, ColorView{Gray{Float32},1,Array{Float32,1}})
+        @test eltype(c) == Gray{Float32}
         @test length(c) == 2
-        c = similar(v, Gray{Float16}, ImageCore.squeeze1 ? (5,5) : (1,5,5))
-        @test isa(c, ColorView{Gray{Float16},2,Array{Float16,2}})
-        @test size(c) == (ImageCore.squeeze1 ? (5,5) : (1,5,5))
+        c = similar(v, Gray{Float16}, (5,5))
+        @test eltype(c) == Gray{Float16}
+        @test size(c) == (5,5)
         c = similar(v, Float32)
         @test isa(c, Array{Float32, 1})
     end
     # two dimensional images and linear indexing
-    _a0 = N0f8[0.2 0.4; 0.6 0.8]
-    a0 = ImageCore.squeeze1 ? _a0 : reshape(_a0, (1, 2, 2))
-    for (a, VT, LI) in ((copy(a0), Array{Gray{N0f8}}, IndexLinear()),
-                        (ArrayLF(copy(a0)), ColorView{Gray{N0f8}}, IndexLinear()),
-                        (ArrayLS(copy(a0)), ColorView{Gray{N0f8}}, IndexCartesian()))
-        @test_throws ErrorException ColorView(a)
-        v = ColorView{Gray}(a)
-        @test isa(colorview(Gray,a), VT)
-        @test IndexStyle(v) == LI
-        @test isa(channelview(v), typeof(a))
+    a0 = N0f8[0.2 0.4; 0.6 0.8]
+    for (a, LI) in ((copy(a0), IndexLinear()),
+                    (ArrayLF(copy(a0)), IndexLinear()),
+                    (ArrayLS(copy(a0)), IndexCartesian()))
+        @test_throws MethodError colorview(a)
+        v = colorview(Gray, a)
+        @test @inferred(IndexStyle(v)) == LI
         @test ndims(v) == 2
         @test size(v) == (2,2)
         @test eltype(v) == Gray{N0f8}
-        @test parent(v) === a
+        @test channelview(v) === a
+        @test parent(parent(v)) === a
         @test v[1] == Gray(N0f8(0.2))
         @test v[2] == Gray(N0f8(0.6))
         @test_throws BoundsError v[0]
@@ -297,16 +281,13 @@ end
 @testset "RGB, HSV, etc" begin
     for T in (RGB, BGR, RGB1, RGB4, HSV, Lab, XYZ)
         a0 = [0.1 0.2 0.3; 0.4 0.5 0.6]'
-        for (a, VT) in ((copy(a0), T<:Union{BGR,RGB1,RGB4} ? ColorView : Array),
-                        (ArrayLS(copy(a0)), ColorView))
-            @test_throws ErrorException ColorView(a)
-            v = ColorView{T}(a)
-            @test isa(@inferred(colorview(T,a)), VT)
-            @test isa(@inferred(channelview(v)), typeof(a))
+        for a in (copy(a0),
+                  ArrayLS(copy(a0)))
+            v = @inferred(colorview(T,a))
+            @test @inferred(channelview(v)) === a
             @test ndims(v) == 1
             @test size(v) == (2,)
             @test eltype(v) == T{Float64}
-            @test parent(v) === a
             @test v[1] == T(0.1,0.2,0.3)
             @test v[2] == T(0.4,0.5,0.6)
             @test_throws BoundsError v[0]
@@ -316,42 +297,30 @@ end
             @test_throws BoundsError (v[0] = T(0.8, 0.7, 0.6))
             @test_throws BoundsError (v[3] = T(0.8, 0.7, 0.6))
             c = similar(v)
-            @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
             @test size(c) == (2,)
             c = similar(v, 4)
-            @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
             @test size(c) == (4,)
             c = similar(v, T{Float32})
-            @test isa(c, ColorView{T{Float32},1,Array{Float32,2}})
             @test size(c) == (2,)
             c = similar(v, T)
-            @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
             @test size(c) == (2,)
             c = similar(v, T{Float16}, (5,5))
-            @test isa(c, ColorView{T{Float16},2,Array{Float16,3}})
             @test size(c) == (5,5)
             c = similar(v, RGB24)
             @test eltype(c) == RGB24
             @test size(c) == size(v)
         end
     end
-    a = rand(ARGB{N0f8}, 5, 5)
-    vc = channelview(a)
-    @test isa(colorview(ARGB, vc), Array{ARGB{N0f8},2})
-    cvc = colorview(RGBA, vc)
-    @test all(cvc .== a)
 end
 
 @testset "Gray+Alpha" begin
-    for (T,VT) in ((AGray,ColorView),(GrayA,Array))
+    for T in (AGray, GrayA)
         a = [0.1f0 0.2f0; 0.3f0 0.4f0; 0.5f0 0.6f0]'
-        v = ColorView{T}(a)
-        @test isa(colorview(T,a), VT{T{Float32}})
-        @test isa(channelview(v), Array)
+        v = colorview(T, a)
         @test ndims(v) == 1
         @test size(v) == (3,)
         @test eltype(v) == T{Float32}
-        @test parent(v) === a
+        @test channelview(v) === a
         @test v[1] == T(0.1f0, 0.2f0)
         @test v[2] == T(0.3f0, 0.4f0)
         @test v[3] == T(0.5f0, 0.6f0)
@@ -363,39 +332,44 @@ end
         @test_throws BoundsError (v[0] = T(0.8,0.7))
         @test_throws BoundsError (v[4] = T(0.8,0.7))
         c = similar(v)
-        @test isa(c, ColorView{T{Float32},1,Array{Float32,2}})
+        @test eltype(c) == T{Float32}
         @test size(c) == (3,)
         c = similar(v, (4,))
-        @test isa(c, ColorView{T{Float32},1,Array{Float32,2}})
+        @test eltype(c) == T{Float32}
         @test size(c) == (4,)
         c = similar(v, T{Float64})
-        @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
+        @test eltype(c) == T{Float64}
         @test size(c) == (3,)
         c = similar(v, T{Float16}, (5,5))
-        @test isa(c, ColorView{T{Float16},2,Array{Float16,3}})
+        @test eltype(c) == T{Float16}
         @test size(c) == (5,5)
     end
 end
 
 @testset "Alpha+RGB, HSV, etc" begin
-    for (T,VT) in ((ARGB, ColorView),
-                   (ABGR, ColorView),
-                   (AHSV, ColorView),
-                   (ALab, ColorView),
-                   (AXYZ, ColorView),
-                   (RGBA, Array),
-                   (BGRA, ColorView),
-                   (HSVA, Array),
-                   (LabA, Array),
-                   (XYZA, Array))
+    a = rand(ARGB{N0f8}, 5, 5)
+    vc = channelview(a)
+    @test eltype(colorview(ARGB, vc)) == ARGB{N0f8}
+    cvc = colorview(RGBA, vc)
+    @test all(cvc .== a)
+
+    for T in (ARGB,
+              ABGR,
+              AHSV,
+              ALab,
+              AXYZ,
+              RGBA,
+              BGRA,
+              HSVA,
+              LabA,
+              XYZA)
         a = [0.1 0.2 0.3 0.4; 0.5 0.6 0.7 0.8]'
-        v = ColorView{T}(a)
-        @test isa(colorview(T,a), VT{T{Float64}})
-        @test isa(channelview(v), Array)
+        v = colorview(T, a)
+        @test eltype(v) == T{Float64}
+        @test channelview(v) === a
         @test ndims(v) == 1
         @test size(v) == (2,)
         @test eltype(v) == T{Float64}
-        @test parent(v) === a
         @test v[1] == T(0.1,0.2,0.3,0.4)
         @test v[2] == T(0.5,0.6,0.7,0.8)
         @test_throws BoundsError v[0]
@@ -408,23 +382,23 @@ end
         @test_throws BoundsError (v[0] = T(0.9,0.8,0.7,0.6))
         @test_throws BoundsError (v[3] = T(0.9,0.8,0.7,0.6))
         c = similar(v)
-        @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
+        @test eltype(c) == T{Float64}
         @test size(c) == (2,)
         c = similar(v, 4)
-        @test isa(c, ColorView{T{Float64},1,Array{Float64,2}})
+        @test eltype(c) == T{Float64}
         @test size(c) == (4,)
         c = similar(v, T{Float32})
-        @test isa(c, ColorView{T{Float32},1,Array{Float32,2}})
+        @test eltype(c) == T{Float32}
         @test size(c) == (2,)
         c = similar(v, T{Float16}, (5,5))
-        @test isa(c, ColorView{T{Float16},2,Array{Float16,3}})
+        @test eltype(c) == T{Float16}
         @test size(c) == (5,5)
     end
 
     @testset "Non-1 indices" begin
         a = OffsetArray(rand(3, 3, 5), 1:3, -1:1, -2:2)
         v = colorview(RGB, a)
-        @test @inferred(indices(v)) === (-1:1, -2:2)
+        @test @inferred(axes(v)) === (Base.Slice(-1:1), Base.Slice(-2:2))
         @test @inferred(v[0,0]) === RGB(a[1,0,0], a[2,0,0], a[3,0,0])
         a = OffsetArray(rand(3, 3, 5), 0:2, -1:1, -2:2)
         @test_throws DimensionMismatch colorview(RGB, a)

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -1,5 +1,5 @@
 using ImageCore, Colors, FixedPointNumbers, OffsetArrays
-using Base.Test
+using Test, Random
 
 @testset "reinterpret" begin
     # Gray
@@ -7,40 +7,35 @@ using Base.Test
         a = rand(Gray{N0f8}, sz)
         for T in (Gray{N0f8}, Gray{Float32}, Gray{Float64})
             b = @inferred(convert(Array{T}, a))
-            rb = @inferred(reinterpret(eltype(T), b))
-            if ImageCore.squeeze1
-                @test isa(rb, Array{eltype(T),length(sz)})
-                @test size(rb) == sz
-            else
-                @test isa(rb, Array{eltype(T),length(sz)+1})
-                @test size(rb) == (1,sz...)
-            end
+            rb = @inferred(reinterpretc(eltype(T), b))
+            @test eltype(rb) == eltype(T) && ndims(rb) == length(sz)
+            @test size(rb) == sz
             c = copy(rb)
-            rc = @inferred(reinterpret(T, c))
-            @test isa(rc, Array{T,length(sz)})
+            rc = @inferred(reinterpretc(T, c))
+            @test eltype(rc) == T && ndims(rc) == length(sz)
             @test size(rc) == sz
         end
     end
     for sz in ((4,), (4,5))
         # Bool/Gray{Bool}
         b = rand(Bool, sz)
-        rb = @inferred(reinterpret(Gray{Bool}, b))
-        @test isa(rb, Array{Gray{Bool}, length(sz)})
+        rb = @inferred(reinterpretc(Gray{Bool}, b))
+        @test eltype(rb) == Gray{Bool} && ndims(rb) == length(sz)
         @test size(rb) == sz
         c = copy(rb)
-        rc = @inferred(reinterpret(Bool, c))
-        @test isa(rc, Array{Bool,length(sz)})
+        rc = @inferred(reinterpretc(Bool, c))
+        @test eltype(rc) == Bool && ndims(rc) == length(sz)
         @test size(rc) == sz
     end
     for sz in ((4,), (4,5))
         b = Gray24.(reinterpret(N0f8, rand(UInt8, sz)))
         for T in (UInt32, RGB24)
-            rb = @inferred(reinterpret(T, b))
-            @test isa(rb, Array{T,length(sz)})
+            rb = @inferred(reinterpretc(T, b))
+            @test eltype(rb) == T && ndims(rb) == length(sz)
             @test size(rb) == sz
             c = copy(rb)
-            rc = @inferred(reinterpret(Gray24, c))
-            @test isa(rc, Array{Gray24,length(sz)})
+            rc = @inferred(reinterpretc(Gray24, c))
+            @test eltype(rc) == Gray24 && ndims(rc) == length(sz)
             @test size(rc) == sz
         end
     end
@@ -48,66 +43,66 @@ using Base.Test
     a = rand(AGray{N0f8}, (4,5))
     for T in (AGray{N0f8}, GrayA{Float32}, AGray{Float64})
         b = @inferred(convert(Array{T}, a))
-        rb = @inferred(reinterpret(eltype(T), b))
-        @test isa(rb, Array{eltype(T),3})
+        rb = @inferred(reinterpretc(eltype(T), b))
+        @test eltype(rb) == eltype(T) && ndims(rb) == 3
         @test size(rb) == (2,4,5)
         c = copy(rb)
-        rc = @inferred(reinterpret(T, c))
-        @test isa(rc, Array{T,2})
+        rc = @inferred(reinterpretc(T, c))
+        @test eltype(rc) == T && ndims(rc) == 2
         @test size(rc) == (4,5)
     end
     # Color3
     a = rand(RGB{N0f8}, (4,5))
     for T in (RGB{N0f8}, HSV{Float32}, XYZ{Float64})
         b = @inferred(convert(Array{T}, a))
-        rb = @inferred(reinterpret(eltype(T), b))
-        @test isa(rb, Array{eltype(T),3})
+        rb = @inferred(reinterpretc(eltype(T), b))
+        @test eltype(rb) == eltype(T) && ndims(rb) == 3
         @test size(rb) == (3,4,5)
         c = copy(rb)
-        rc = @inferred(reinterpret(T, c))
-        @test isa(rc, Array{T,2})
+        rc = @inferred(reinterpretc(T, c))
+        @test eltype(rc) == T && ndims(rc) == 2
         @test size(rc) == (4,5)
     end
     for a in (rand(RGB{N0f8}, 4), rand(RGB{N0f8}, (4,5)))
-        b = @inferred(reinterpret(HSV{Float32}, float32.(a)))
-        @test isa(b, Array{HSV{Float32}})
+        b = @inferred(reinterpretc(HSV{Float32}, float32.(a)))
+        @test eltype(b) == HSV{Float32}
         @test ndims(b) == ndims(a)
     end
     # Transparent color
     a = rand(ARGB{N0f8}, (4,5))
     for T in (ARGB{N0f8}, AHSV{Float32}, AXYZ{Float64})
         b = @inferred(convert(Array{T}, a))
-        rb = @inferred(reinterpret(eltype(T), b))
-        @test isa(rb, Array{eltype(T),3})
+        rb = @inferred(reinterpretc(eltype(T), b))
+        @test eltype(rb) == eltype(T) && ndims(rb) == 3
         @test size(rb) == (4,4,5)
         c = copy(rb)
-        rc = @inferred(reinterpret(T, c))
-        @test isa(rc, Array{T,2})
+        rc = @inferred(reinterpretc(T, c))
+        @test eltype(rc) == T && ndims(rc) == 2
         @test size(rc) == (4,5)
     end
     # RGB1/RGB4
     a = rand(RGB{N0f8}, (4,5))
     for T in (RGB1{N0f8},RGB4{Float32})
         b = @inferred(convert(Array{T}, a))
-        rb = @inferred(reinterpret(eltype(T), b))
-        @test isa(rb, Array{eltype(T),3})
+        rb = @inferred(reinterpretc(eltype(T), b))
+        @test eltype(rb) == eltype(T) && ndims(rb) == 3
         @test size(rb) == (4,4,5)
         c = copy(rb)
-        rc = @inferred(reinterpret(T, c))
-        @test isa(rc, Array{T,2})
+        rc = @inferred(reinterpretc(T, c))
+        @test eltype(rc) == T && ndims(rc) == 2
         @test size(rc) == (4,5)
     end
     a = [RGB(1,0,0) RGB(0,0,1);
          RGB(0,1,0) RGB(1,1,1)]
-    @test @inferred(reinterpret(N0f8, a)) == cat(3, [1 0; 0 1; 0 0], [0 1; 0 1; 1 1])
+    @test @inferred(reinterpretc(N0f8, a)) == cat([1 0; 0 1; 0 0], [0 1; 0 1; 1 1]; dims=3)
     b = convert(Array{BGR{N0f8}}, a)
-    @test @inferred(reinterpret(N0f8, b)) == cat(3, [0 0; 0 1; 1 0], [1 1; 0 1; 0 1])
+    @test @inferred(reinterpretc(N0f8, b)) == cat([0 0; 0 1; 1 0], [1 1; 0 1; 0 1]; dims=3)
     # RGB24, ARGB32
     for sz in ((4,), (4,5))
         a = rand(UInt32, sz)
         for T in (RGB24, ARGB32)
-            b = @inferred(reinterpret(T, a))
-            @test isa(b, Array{T,length(sz)})
+            b = @inferred(reinterpretc(T, a))
+            @test eltype(b) == T && ndims(b) == length(sz)
             @test size(b) == sz
             @test eltype(b) == T
             @test @inferred(reinterpret(UInt32, b)) == a
@@ -116,39 +111,33 @@ using Base.Test
 
     # 1d
     a = RGB{Float64}[RGB(1,1,0)]
-    af = @inferred(reinterpret(Float64, a))
-    anew = @inferred(reinterpret(RGB, vec(af)))
+    af = @inferred(reinterpretc(Float64, a))
+    anew = @inferred(reinterpretc(RGB, vec(af)))
     @test anew[1] == a[1]
     @test ndims(anew) == 1
 
     # #33 and its converse
-    a = reinterpret(BGRA{N0f8}, [0xf0884422])
-    @test isa(a, Vector) && a == [BGRA{N0f8}(0.533,0.267,0.133,0.941)]
-    @test reinterpret(UInt32, a) == [0xf0884422]
-    @test size(reinterpret(BGRA{N0f8}, rand(UInt32, 5, 5))) == (5,5)
+    a = reinterpretc(BGRA{N0f8}, [0xf0884422])
+    @test isa(a, AbstractVector) && a == [BGRA{N0f8}(0.533,0.267,0.133,0.941)]
+    @test reinterpretc(UInt32, a) == [0xf0884422]
+    @test size(reinterpretc(BGRA{N0f8}, rand(UInt32, 5, 5))) == (5,5)
     @test size(colorview(ARGB32, rand(BGRA{N0f8}, 5, 5))) == (5,5)
-    a = reinterpret(BGRA{N0f8}, [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04])
+    a = reinterpretc(BGRA{N0f8}, [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04])
     @test a == [BGRA{N0f8}(0.533,0.267,0.133,0.941), BGRA{N0f8}(0.012, 0.008, 0.004, 0.016)]
     @test reinterpret(UInt8, a) == [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04]
-    @test colorview(ARGB32, a) == reinterpret(ARGB32, [0xf0884422,0x04030201])
+    @test colorview(ARGB32, a) == reinterpretc(ARGB32, [0xf0884422,0x04030201])
 
     # indeterminate type tests
-    a = Array{RGB{AbstractFloat}}(3)
-    @test_throws ArgumentError reinterpret(Float64, a)
-    if VERSION < v"0.7.0-DEV"
-        Tu = TypeVar(:T)
-        a = Array{RGB{Tu}}(3)
-        @test_throws ErrorException reinterpret(Float64, a)
-    else
-        a = Vector{RGB}(3)
-        @test_throws ErrorException reinterpret(Float64, a)
-    end
+    a = Array{RGB{AbstractFloat}}(undef, 3)
+    @test_throws ErrorException reinterpretc(Float64, a)
+    a = Vector{RGB}(undef, 3)
+    @test_throws ErrorException reinterpretc(Float64, a)
 
     # Invalid conversions
     a = rand(UInt8, 4,5)
-    ret = @test_throws TypeError reinterpret(Gray, a)
+    ret = @test_throws TypeError reinterpretc(Gray, a)
     a = rand(Int8, 4,5)
-    ret = @test_throws TypeError reinterpret(Gray, a)
+    ret = @test_throws TypeError reinterpretc(Gray, a)
 end
 
 @testset "convert" begin
@@ -178,7 +167,7 @@ end
         @test eltype(s) == Gray{Float32}
         @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
-        @test indices(s) === indices(imgo)
+        @test axes(s) === axes(imgo)
     end
 
     for img in ( Gray.(A),
@@ -189,7 +178,7 @@ end
         @test eltype(s) == Gray{N0f8}
         @test s isa OffsetArray{Gray{N0f8},2,Array{Gray{N0f8},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
-        @test indices(s) === indices(imgo)
+        @test axes(s) === axes(imgo)
     end
 
     for img in ( Gray.(A),
@@ -200,7 +189,7 @@ end
         @test eltype(s) == Gray{N0f16}
         @test s isa OffsetArray{Gray{N0f16},2,Array{Gray{N0f16},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
-        @test indices(s) === indices(imgo)
+        @test axes(s) === axes(imgo)
     end
 
     # Color images wrapped by an OffsetArray.
@@ -216,7 +205,7 @@ end
         @test eltype(s) == RGB{N0f8}
         @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
-        @test indices(s) === indices(imgo)
+        @test axes(s) === axes(imgo)
     end
 
     A = rand(RGB{Float32},8,8)
@@ -231,7 +220,7 @@ end
         @test eltype(s) == RGB{Float32}
         @test s isa OffsetArray{RGB{Float32},2,Array{RGB{Float32},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
-        @test indices(s) === indices(imgo)
+        @test axes(s) === axes(imgo)
     end
 end
 
@@ -273,7 +262,7 @@ end
 #    @test eltype(float16.(a)) == Float16
     @test eltype(float32.(a)) == Float32
     @test eltype(float64.(a)) == Float64
-    @test indices(float32.(a)) == (-1:1,)
+    @test axes(float32.(a)) == (-1:1,)
 end
 
 @testset "ambiguities" begin

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -114,7 +114,7 @@ using Test, Random
     af = @inferred(reinterpretc(Float64, a))
     anew = @inferred(reinterpretc(RGB, vec(af)))
     @test anew[1] == a[1]
-    @test ndims(anew) == 1
+    @test ndims(anew) == 0
 
     # #33 and its converse
     a = reinterpretc(BGRA{N0f8}, [0xf0884422])
@@ -122,7 +122,7 @@ using Test, Random
     @test reinterpretc(UInt32, a) == [0xf0884422]
     @test size(reinterpretc(BGRA{N0f8}, rand(UInt32, 5, 5))) == (5,5)
     @test size(colorview(ARGB32, rand(BGRA{N0f8}, 5, 5))) == (5,5)
-    a = reinterpretc(BGRA{N0f8}, [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04])
+    a = reinterpretc(BGRA{N0f8}, reshape([0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04], 4, 2))
     @test a == [BGRA{N0f8}(0.533,0.267,0.133,0.941), BGRA{N0f8}(0.012, 0.008, 0.004, 0.016)]
     @test reinterpret(UInt8, a) == [0x22, 0x44, 0x88, 0xf0, 0x01, 0x02, 0x03, 0x04]
     @test colorview(ARGB32, a) == reinterpretc(ARGB32, [0xf0884422,0x04030201])

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,6 +1,6 @@
 using ImageCore, Colors, FixedPointNumbers
 using FFTW
-using Base.Test
+using Test
 
 @testset "functions" begin
     ag = rand(Gray{Float32}, 4, 5)
@@ -10,14 +10,14 @@ using Base.Test
                       (fft, (ac,)), (fft, (ac, 1:2)), (plan_fft, (ac,)),
                       (rfft, (ac,)), (rfft, (ac, 1:2)), (plan_rfft, (ac,)))
         ret = @test_throws ErrorException f(args...)
-        @test contains(ret.value.msg, "channelview")
-        @test contains(ret.value.msg, eltype(args[1])<:Gray ? "1:2" : "2:3")
+        @test occursin("channelview", ret.value.msg)
+        @test occursin(eltype(args[1])<:Gray ? "1:2" : "2:3", ret.value.msg)
     end
     for (a, dims) in ((ag, 1:2), (ac, 2:3))
         @test ifft(fft(channelview(a), dims), dims) ≈ channelview(a)
         ret = @test_throws ErrorException rfft(a)
-        @test contains(ret.value.msg, "channelview")
-        @test contains(ret.value.msg, "$dims")
+        @test occursin("channelview", ret.value.msg)
+        @test occursin("$dims", ret.value.msg)
         @test irfft(rfft(channelview(a), dims), 4, dims) ≈ channelview(a)
     end
 

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,5 +1,5 @@
 using ImageCore, FixedPointNumbers, Colors, ColorVectorSpace
-using Base.Test
+using Test
 
 @testset "map" begin
     @testset "clamp01" begin
@@ -82,7 +82,7 @@ using Base.Test
         A = [Gray(-0.1),Gray(0.1)]
         f = scaleminmax(Gray, -0.1, 0.1)
         @test f.(A) == [Gray(0.0),Gray(1.0)]
-        A = reinterpret(RGB, [0.0 128.0; 255.0 0.0; 0.0 0.0])
+        A = reinterpretc(RGB, [0.0 128.0; 255.0 0.0; 0.0 0.0])
         f = scaleminmax(RGB, 0, 255)
         @test f.(A) == [RGB(0,1.0,0), RGB(128/255,0,0)]
         f = scaleminmax(RGB{N0f8}, 0, 255)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 module ImageCoreTests
 
-using ImageCore, Base.Test
+using ImageCore, Test
 
-@test isempty(detect_ambiguities(ImageCore, Base, Core))
+# If we've run the tests previously, there might be ambiguities from other packages
+if :StatsBase ∉ map(x->Symbol(string(x)), values(Base.loaded_modules))
+    @test isempty(detect_ambiguities(ImageCore, Base, Core))
+end
 
 include("colorchannels.jl")
 include("views.jl")
@@ -15,7 +18,7 @@ include("show.jl")
 # run these last
 isCI = haskey(ENV, "CI") || get(ENV, "JULIA_PKGEVAL", false)
 if Base.JLOptions().can_inline == 1 && !isCI
-    info("running benchmarks")
+    @info "running benchmarks"
     include("benchmarks.jl")  # these fail if inlining is off
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -12,13 +12,13 @@ using ImageCore, Colors, FixedPointNumbers, OffsetArrays, Test
     v = view(rgb32, 2:3, :)
     @test summary(v) == "2×5 view(::Array{RGB{Float32},2}, 2:3, :) with eltype $(prefixC)RGB{Float32}"
     a = channelview(rgb32)
-    @test summary(a) == "3×3×5 reshape(reinterpret(Float32, ::Array{RGB{Float32},2}), 3, 3, 5) with eltype Float32"
+    @test summary(a) == "3×3×5 reinterpret(Float32, ::Array{RGB{Float32},3})"
     num64 = rand(3,5)
     b = colorview(RGB, num64)
     @test summary(b) == "5-element reshape(reinterpret(RGB{Float64}, ::Array{Float64,2}), 5) with eltype $(prefixC)RGB{Float64}"
     rgb8 = rand(RGB{N0f8}, 3, 5)
     c = rawview(channelview(rgb8))
-    @test summary(c) == "3×3×5 rawview(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5)) with eltype UInt8"
+    @test summary(c) == "3×3×5 rawview(reinterpret(N0f8, ::Array{RGB{N0f8},3})) with eltype UInt8"
     @test summary(rgb8) == "3×5 Array{RGB{N0f8},2} with eltype $(prefixC)RGB{$(prefixF)Normed{UInt8,8}}"
     rand8 = rand(UInt8, 3, 5)
     d = normedview(permuteddimsview(rand8, (2,1)))
@@ -28,14 +28,14 @@ using ImageCore, Colors, FixedPointNumbers, OffsetArrays, Test
     f = permuteddimsview(normedview(N0f16, rand(UInt16, 3, 5)), (2,1))
     @test summary(f) == "5×3 PermutedDimsArray(reinterpret(N0f16, ::Array{UInt16,2}), (2, 1)) with eltype $(prefixF)Normed{UInt16,16}"
     g = channelview(rgb8)
-    @test summary(g) == "3×3×5 reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5) with eltype $(prefixF)Normed{UInt8,8}"
+    @test summary(g) == "3×3×5 reinterpret(N0f8, ::Array{RGB{N0f8},3})"
     h = OffsetArray(rgb8, -1:1, -2:2)
     @test summary(h) == "OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype $(prefixC)RGB{$(prefixF)Normed{UInt8,8}} with indices -1:1×-2:2"
     i = channelview(h)
-    @test summary(i) == "OffsetArray(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5), 1:3, -1:1, -2:2) with eltype $(prefixF)Normed{UInt8,8} with indices 1:3×-1:1×-2:2"
+    @test summary(i) == "reinterpret(N0f8, OffsetArray(::Array{RGB{N0f8},3}, 1:1, -1:1, -2:2)) with indices 1:3×-1:1×-2:2"
     c = channelview(rand(RGB{N0f8}, 2))
     o = OffsetArray(c, -1:1, 0:1)
-    @test summary(o) == "OffsetArray(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},1}), 3, 2), -1:1, 0:1) with eltype $(prefixF)Normed{UInt8,8} with indices -1:1×0:1"
+    @test summary(o) == "OffsetArray(reinterpret(N0f8, ::Array{RGB{N0f8},2}), -1:1, 0:1) with eltype $(prefixF)Normed{UInt8,8} with indices -1:1×0:1"
     # Issue #45
     a = collect(tuple())
     @test summary(a) == "0-element Array{Union{},1}"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,44 +1,46 @@
-using ImageCore, Colors, FixedPointNumbers, OffsetArrays, Base.Test
-
-tformat(x...) = join(string.(x), ", ")
-
-const showit_old = VERSION < v"0.7.0-DEV.1790"
-const eltype_string = showit_old ? "element type" : "eltype"
+using ImageCore, Colors, FixedPointNumbers, OffsetArrays, Test
 
 @testset "show" begin
+    thismodule = string(@__MODULE__)
+    if thismodule != "Main"
+        prefixF = "FixedPointNumbers."
+        prefixC = "ColorTypes."
+    else
+        prefixF = prefixC = ""
+    end
     rgb32 = rand(RGB{Float32}, 3, 5)
     v = view(rgb32, 2:3, :)
-    @test summary(v) == "2×5 view(::Array{RGB{Float32},2}, 2:3, :) with $eltype_string ColorTypes.RGB{Float32}"
-    a = ChannelView(rgb32)
-    @test summary(a) == "3×3×5 ChannelView(::Array{RGB{Float32},2}) with $eltype_string Float32"
+    @test summary(v) == "2×5 view(::Array{RGB{Float32},2}, 2:3, :) with eltype $(prefixC)RGB{Float32}"
+    a = channelview(rgb32)
+    @test summary(a) == "3×3×5 reshape(reinterpret(Float32, ::Array{RGB{Float32},2}), 3, 3, 5) with eltype Float32"
     num64 = rand(3,5)
-    b = ColorView{RGB}(num64)
-    @test summary(b) == "5-element ColorView{RGB}(::Array{Float64,2}) with $eltype_string ColorTypes.RGB{Float64}"
+    b = colorview(RGB, num64)
+    @test summary(b) == "5-element reshape(reinterpret(RGB{Float64}, ::Array{Float64,2}), 5) with eltype $(prefixC)RGB{Float64}"
     rgb8 = rand(RGB{N0f8}, 3, 5)
-    c = rawview(ChannelView(rgb8))
-    @test summary(c) == "3×3×5 rawview(ChannelView(::Array{RGB{N0f8},2})) with $eltype_string UInt8"
-    @test summary(rgb8) == "3×5 Array{RGB{N0f8},2}"
+    c = rawview(channelview(rgb8))
+    @test summary(c) == "3×3×5 rawview(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5)) with eltype UInt8"
+    @test summary(rgb8) == "3×5 Array{RGB{N0f8},2} with eltype $(prefixC)RGB{$(prefixF)Normed{UInt8,8}}"
     rand8 = rand(UInt8, 3, 5)
     d = normedview(permuteddimsview(rand8, (2,1)))
-    @test summary(d) == "5×3 normedview(N0f8, PermutedDimsArray(::Array{UInt8,2}, $(tformat((2,1))))) with $eltype_string FixedPointNumbers.Normed{UInt8,8}"
+    @test summary(d) == "5×3 normedview(N0f8, PermutedDimsArray(::Array{UInt8,2}, (2, 1))) with eltype $(prefixF)Normed{UInt8,8}"
     e = permuteddimsview(normedview(rand8), (2,1))
-    @test summary(e) == "5×3 PermutedDimsArray(::Array{N0f8,2}, $(tformat((2,1)))) with $eltype_string FixedPointNumbers.Normed{UInt8,8}"
+    @test summary(e) == "5×3 PermutedDimsArray(reinterpret(N0f8, ::Array{UInt8,2}), (2, 1)) with eltype $(prefixF)Normed{UInt8,8}"
     f = permuteddimsview(normedview(N0f16, rand(UInt16, 3, 5)), (2,1))
-    @test summary(f) == "5×3 PermutedDimsArray(::Array{N0f16,2}, $(tformat((2,1)))) with $eltype_string FixedPointNumbers.Normed{UInt16,16}"
+    @test summary(f) == "5×3 PermutedDimsArray(reinterpret(N0f16, ::Array{UInt16,2}), (2, 1)) with eltype $(prefixF)Normed{UInt16,16}"
     g = channelview(rgb8)
-    @test summary(g) == (showit_old ? "3×3×5 Array{N0f8,3}" : "3×3×5 Array{N0f8,3} with eltype FixedPointNumbers.Normed{UInt8,8}")
+    @test summary(g) == "3×3×5 reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5) with eltype $(prefixF)Normed{UInt8,8}"
     h = OffsetArray(rgb8, -1:1, -2:2)
-    @test summary(h) == (showit_old ? "-1:1×-2:2 OffsetArray{RGB{N0f8},2}" : "OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}} with indices -1:1×-2:2")
+    @test summary(h) == "OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype $(prefixC)RGB{$(prefixF)Normed{UInt8,8}} with indices -1:1×-2:2"
     i = channelview(h)
-    @test summary(i) == (showit_old ? "1:3×-1:1×-2:2 ChannelView(::OffsetArray{RGB{N0f8},2}) with $eltype_string FixedPointNumbers.Normed{UInt8,8}" : "ChannelView(OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2)) with eltype FixedPointNumbers.Normed{UInt8,8} with indices 1:3×-1:1×-2:2")
-    c = ChannelView(rand(RGB{N0f8}, 2))
+    @test summary(i) == "OffsetArray(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},2}), 3, 3, 5), 1:3, -1:1, -2:2) with eltype $(prefixF)Normed{UInt8,8} with indices 1:3×-1:1×-2:2"
+    c = channelview(rand(RGB{N0f8}, 2))
     o = OffsetArray(c, -1:1, 0:1)
-    @test summary(o) == (showit_old ? "-1:1×0:1 OffsetArray{N0f8,2,ImageCore.ChannelView{FixedPointNumbers.Normed{UInt8,8},2,Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8,8}},1}}}" :  "OffsetArray(ChannelView(::Array{RGB{N0f8},1}), -1:1, 0:1) with eltype FixedPointNumbers.Normed{UInt8,8} with indices -1:1×0:1")
+    @test summary(o) == "OffsetArray(reshape(reinterpret(N0f8, ::Array{RGB{N0f8},1}), 3, 2), -1:1, 0:1) with eltype $(prefixF)Normed{UInt8,8} with indices -1:1×0:1"
     # Issue #45
     a = collect(tuple())
     @test summary(a) == "0-element Array{Union{},1}"
     b = view(a, :)
-    @test summary(b) == "0-element view(::Array{Union{},1}, :) with $eltype_string Union{}"
+    @test summary(b) == "0-element view(::Array{Union{},1}, :) with eltype Union{}"
 end
 
 nothing

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,5 +1,5 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
-using Base.Test
+using Test
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),

--- a/test/views.jl
+++ b/test/views.jl
@@ -1,5 +1,5 @@
 # some views are in colorchannels.jl
-using Colors, FixedPointNumbers, ImageCore, OffsetArrays, Base.Test
+using Colors, FixedPointNumbers, ImageCore, OffsetArrays, Test
 
 @testset "rawview" begin
     a = map(N0f8, rand(3,5))
@@ -53,7 +53,7 @@ end
         V = @inferred(StackedView(A, B))
         @test eltype(V) == T
         @test size(V) == (2, 2, 2)
-        @test indices(V) === (Base.OneTo(2), Base.OneTo(2), Base.OneTo(2))
+        @test axes(V) === (Base.OneTo(2), Base.OneTo(2), Base.OneTo(2))
         @test @inferred(V[1,1,1]) === T(1)
         @test @inferred(V[2,1,1]) === T(-1)
         @test V[1,:,:] == A
@@ -75,7 +75,7 @@ end
         V = @inferred(StackedView(A, zeroarray, B))
         @test eltype(V) == T
         @test size(V) == (3, 2, 2)
-        @test indices(V) === (Base.OneTo(3), Base.OneTo(2), Base.OneTo(2))
+        @test axes(V) === (Base.OneTo(3), Base.OneTo(2), Base.OneTo(2))
         @test V[1,:,:] == A
         @test all(V[2,:,:] .== 0)
         @test V[3,:,:] == B
@@ -145,7 +145,7 @@ end
     @test cv[2,1] === RGB(0.2,0,0)
     @test cv[1,2] === RGB(0,1.0,0)
     @test cv[2,2] === RGB(0,0.0,0)
-    @test indices(cv) === (Base.OneTo(2), Base.OneTo(2))
+    @test axes(cv) === (Base.OneTo(2), Base.OneTo(2))
 
     a = [0.1 0.2; 0.3 0.4]
     b = OffsetArray([0.1 0.2; 0.3 0.4], 0:1, 2:3)

--- a/test/views.jl
+++ b/test/views.jl
@@ -151,12 +151,16 @@ end
     b = OffsetArray([0.1 0.2; 0.3 0.4], 0:1, 2:3)
     @test_throws DimensionMismatch colorview(RGB, a, b, zeroarray)
     cv = colorview(RGB, paddedviews(0, a, b, zeroarray)...)
-    @test indices(cv) == (0:2, 1:3)
-    @test red.(cv[indices(a)...]) == a
-    @test green.(cv[indices(b)...]) == parent(b)
+    @test axes(cv) == (0:2, 1:3)
+    @test red.(cv[axes(a)...]) == a
+    @test green.(cv[axes(b)...]) == b
     @test parent(copy(cv)) == [RGB(0,0,0)   RGB(0,0.1,0)   RGB(0,0.2,0);
                                RGB(0.1,0,0) RGB(0.2,0.3,0) RGB(0,0.4,0);
                                RGB(0.3,0,0) RGB(0.4,0,0)   RGB(0,0,0)]
+    chanv = channelview(cv)
+    @test @inferred(axes(chanv)) === (Base.Slice(1:3), Base.Slice(0:2), Base.Slice(1:3))
+    @test chanv[1,1,1] == 0.1
+    @test chanv[2,1,2] == 0.3
 
     @test_throws ErrorException paddedviews(0, zeroarray, zeroarray)
 


### PR DESCRIPTION
The strategy used here for `ColorView` and `ChannelView` has been implemented in a much more general way for `Base.ReinterpretArray`. It makes sense to leverage the Base implementation. Plus, now that `reinterpret` is no longer restricted to `Array`, it turns out that we run into certain dispatch problems that stem from changing the dimensionality to handle/subsume color channels. The solution here is to introduce a `reinterpretc` that is specifically for handling colors. Consequently this is completely breaking.

Not working fully yet, though lots of progress has been made.
