### PR TITLE
Fix channelview() for 1-D inputs

### DIFF
--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -242,13 +242,17 @@ array will be in constructor-argument order, not memory order (see
 channelview(A::AbstractArray{T}) where {T<:Number} = A
 channelview(A::AbstractArray) = ChannelView(A)
 channelview(A::ColorView) = parent(A)
-channelview(A::Array{RGB{T}}) where {T} = reinterpret(T, A)
+channelview(A::Array{RGB{T}}) where {T} = _reinterpret_channels(T, A)
 channelview(A::Array{C}) where {C<:AbstractRGB} = ChannelView(A) # BGR, RGB1, etc don't satisfy conditions
-channelview(A::Array{C}) where {C<:Color} = reinterpret(eltype(C), A)
+channelview(A::Array{C}) where {C<:Color} = _reinterpret_channels(eltype(C), A)
 channelview(A::Array{C}) where {C<:ColorAlpha} = _channelview(base_color_type(C), A)
-_channelview(::Type{RGB}, A) = reinterpret(eltype(eltype(A)), A)
+_channelview(::Type{RGB}, A) = _reinterpret_channels(eltype(eltype(A)), A)
 _channelview(::Type{C}, A) where {C<:AbstractRGB} = ChannelView(A)
-_channelview(::Type{C}, A) where {C<:Color} = reinterpret(eltype(eltype(A)), A)
+_channelview(::Type{C}, A) where {C<:Color} = _reinterpret_channels(eltype(eltype(A)), A)
+
+_reinterpret_channels(::Type{T}, A::Array{C}) where {T<:Number, C<:Colorant} =
+    reinterpret(T, A, channelview_size(A))
+
 
 
 """

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -29,6 +29,8 @@ Base.setindex!(A::ArrayLS{T,N}, val, i::Vararg{Int,N}) where {T,N} = A.A[i...] =
                        (ArrayLS(copy(a0)), ChannelView, IndexCartesian()))
         v = ChannelView(a)
         @test isa(channelview(a), VT)
+        @test size(channelview(a)) == size(v)
+        @test channelview(a) == v
         @test IndexStyle(v) == LI
         @test isa(colorview(Gray, v), typeof(a))
         @test ndims(v) == 2 - ImageCore.squeeze1
@@ -65,6 +67,8 @@ end
                         (ArrayLS(copy(a0)), ChannelView))
             v = ChannelView(a)
             @test isa(channelview(a), VT)
+            @test size(channelview(a)) == size(v)
+            @test channelview(a) == v
             @test isa(colorview(T, v), typeof(a))
             @test ndims(v) == 2
             @test size(v) == (3,2)
@@ -116,6 +120,8 @@ end
         a = [T(0.1f0,0.2f0), T(0.3f0,0.4f0), T(0.5f0,0.6f0)]
         v = ChannelView(a)
         @test isa(channelview(a), VT)
+        @test size(channelview(a)) == size(v)
+        @test channelview(a) == v
         @test isa(colorview(T, v), Array)
         @test ndims(v) == 2
         @test size(v) == (2,3)
@@ -170,6 +176,8 @@ end
         a = [T(0.1,0.2,0.3,0.4), T(0.5,0.6,0.7,0.8)]
         v = ChannelView(a)
         @test isa(channelview(a), VT)
+        @test size(channelview(a)) == size(v)
+        @test channelview(a) == v
         @test isa(colorview(T, v), Array)
         @test ndims(v) == 2
         @test size(v) == (4,2)


### PR DESCRIPTION
Fixes https://github.com/JuliaImages/Images.jl/issues/669

Previously, `channelview(x::Vector{<:Colorant})` would return a (potentially longer) `Vector`, rather than adding a color dimension (but `ChannelView` would do the correct thing). This wasn't caught in the past because the tests all used `ChannelView` instead of `channelview`. 

This PR changes `channelview()` to always return something of size `channelview_size(A)`, which fixes the above issue and also should ensure that the two functions continue to match in the future. 