### PR TITLE
Fixes broken permutedims for OffsetArray

### DIFF
--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -112,6 +112,11 @@ function Base.convert(::Type{OffsetArray{Cdest,n,A}},
     copy!(OffsetArray{ccolor(Cdest, Csrc)}(Compat.axes(img)),img)
 end
 
+function Base.convert(::Type{OffsetArray{C,n,A}},
+                      img::AbstractArray{C,n}) where {C<:Colorant,n, A <:AbstractArray}
+    img
+end
+
 # for docstrings in the operations below
 shortname(::Type{T}) where {T<:FixedPoint} = (io = IOBuffer(); FixedPointNumbers.showtype(io, T); String(take!(io)))
 shortname(::Type{T}) where {T} = string(T)

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -177,6 +177,7 @@ end
         s = @inferred(convert(OffsetArray{Gray{Float32},2,Array{Gray{Float32}}},imgo))
         @test eltype(s) == Gray{Float32}
         @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
         @test indices(s) === indices(imgo)
     end
 
@@ -187,6 +188,7 @@ end
         s = @inferred(convert(OffsetArray{Gray{N0f8},2,Array{Gray{N0f8}}},imgo))
         @test eltype(s) == Gray{N0f8}
         @test s isa OffsetArray{Gray{N0f8},2,Array{Gray{N0f8},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
         @test indices(s) === indices(imgo)
     end
 
@@ -197,6 +199,7 @@ end
         s = @inferred(convert(OffsetArray{Gray{N0f16},2,Array{Gray{N0f16}}},imgo))
         @test eltype(s) == Gray{N0f16}
         @test s isa OffsetArray{Gray{N0f16},2,Array{Gray{N0f16},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
         @test indices(s) === indices(imgo)
     end
 
@@ -212,6 +215,7 @@ end
         s = @inferred(convert(OffsetArray{RGB{N0f8},2,Array{RGB{N0f8}}},imgo))
         @test eltype(s) == RGB{N0f8}
         @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
         @test indices(s) === indices(imgo)
     end
 
@@ -226,6 +230,7 @@ end
         s = @inferred(convert(OffsetArray{RGB{Float32},2,Array{RGB{Float32}}},imgo))
         @test eltype(s) == RGB{Float32}
         @test s isa OffsetArray{RGB{Float32},2,Array{RGB{Float32},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
         @test indices(s) === indices(imgo)
     end
 end


### PR DESCRIPTION
A previous commit added type conversion rules for Gray and Color images that are wrapped by an OffsetArray. The conversion process involved copying the contents of a source array into a new destination array with a specified destination type. However, when one calls `convert` and the destination type equals the current type, then there is no need to copy the contents of the source array into a new destination array. The previous conversion rule did not take this fact into account and made a copy anyway. Consequently, the conversion rule broke `permutedims` which uses a `PermuteDimsArray` to attempt to create a `view` of the original data.  In particular, the previous conversion rule hijacked dispatch and prevented the following default conversion rule from executing:   `convert(::Type{T}, x::T) where {T} = x`

The present commit addresses corrects this oversight by ensuring that no data is copied when the target type equals the current type. This restores the ability for `PermutedDimsArray` to create the requisite view.