### PR TITLE
[WIP] add traits for general image type

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -74,6 +74,7 @@ export
     width,
     widthheight,
     image_type,
+    AbstractImage,
     GrayImage,
     RGBImage
 

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -72,7 +72,10 @@ export
     spacedirections,
     spatialorder,
     width,
-    widthheight
+    widthheight,
+    image_type,
+    GrayImage,
+    RGBImage
 
 include("colorchannels.jl")
 include("stackedviews.jl")

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -193,3 +193,38 @@ _subarray_offset(off, x::Tuple{}) = ()
 @inline _getindex_tuple(t::Tuple, inds::Tuple) =
     (t[inds[1]], _getindex_tuple(t, tail(inds))...)
 _getindex_tuple(t::Tuple, ::Tuple{}) = ()
+
+# ImageType trait
+abstract type AbstractImage end
+
+struct GenericImage <: AbstractImage end
+image_type(::Type{<:AbstractArray}) = GenericImage()
+
+struct GrayImage <: AbstractImage end
+image_type(::Type{<:AbstractArray{Gray{T}}}) where {T<:Number} = GrayImage()
+image_type(::Type{<:Base.ReinterpretArray{T, 2, Gray{T}, <:AbstractArray{Gray{T},2} }}) where {T<:Number} = GrayImage() # capture channelview
+image_type(::Type{<:MappedArray{RT, 2, <:Base.ReinterpretArray{T, 2, Gray{T}, <:AbstractArray{Gray{T},2}} }}) where {RT<:Number, T<:Number} = GrayImage() # capture rawview
+  
+struct RGBImage <: AbstractImage end
+image_type(::Type{<:AbstractArray{RGB{T}}}) where {T<:Number} = RGBImage()
+image_type(::Type{<:Base.ReinterpretArray{T, 3, RGB{T}, <:AbstractArray{RGB{T},3}}}) where {T<:Number} = RGBImage() # capture channelview
+image_type(::Type{<:MappedArray{RT, 3, <:Base.ReinterpretArray{T, 3, RGB{T}, <:AbstractArray{RGB{T},3}} }}) where {RT<:Number, T<:Number} = RGBImage() # capture rawview
+
+"""
+    image_type(::Type)::AbstractImage
+
+`image_type` returns the type of an image
+
+# Examples
+
+```julia-doc
+img = testimage("cameraman")
+image_type(typeof(img)) == GrayImageType()
+```
+
+```julia-doc
+img = testimage("lena_color_256")
+image_type(typeof(img)) == RGBImageType()
+```
+"""
+image_type

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -31,6 +31,11 @@ using Test
         @test width(B) == 5
         @test height(B) == 3
     end
+
+    @testset "Image types" begin
+        @test isa(image_type(typeof(rand(Gray{Float32}, 3,5))), GrayImage)
+        @test isa(image_type(typeof(rand(RGB{Float16}, 3,5))), RGBImage)
+    end
 end
 
 nothing


### PR DESCRIPTION
This avoids hand-written type dispatch on different kinds of arrays and array elements

Usage:

```julia
function denoise(::GenericImage, img::AbstractArray)
# generic
end

function denoise(::GrayImage, img::AbstractArray)
# gray
end

function denoise(::RGBImage, img::AbstractArray)
# rgb
end

denoise(img::T) where {T<:AbstractArray} = denoise(image_type(T), img)
```

I can keep working on the details, just want to get early feedbacks from you on this pattern. @JuliaImages/founders @zygmuntszpak 