### PR TITLE
reexport Colors and FixedPointNumbers (fixes #74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml
 docs/build/
 docs/site/
 docs/notebooks/.ipynb_checkpoints

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/Project.toml
+++ b/Project.toml
@@ -11,18 +11,21 @@ Graphics = "a2bd30eb-e257-5431-a919-1863eab51364"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-julia = ">= 1.0"
-FixedPointNumbers = ">= 0.3.0"
 ColorTypes = ">= 0.7.5"
+FixedPointNumbers = ">= 0.3.0"
 MappedArrays = ">= 0.2"
-PaddedViews = ">= 0.4.1"
 OffsetArrays = ">= 0.8"
+PaddedViews = ">= 0.4.1"
+Reexport = ">= 0.2"
+julia = ">= 1.0"
 
 [extras]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorVectorSpace", "Test"]
+test = ["ColorVectorSpace", "Statistics", "Test"]

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -2,7 +2,10 @@ VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module ImageCore
 
-using Colors, FixedPointNumbers, MappedArrays, PaddedViews, Graphics
+using Reexport
+@reexport using Colors
+@reexport using FixedPointNumbers
+using MappedArrays, PaddedViews, Graphics
 using OffsetArrays # for show.jl
 using ColorTypes: colorant_string
 using Colors: Fractional


### PR DESCRIPTION
Almost all downstream packages needs explicitly using these two
packages. Reexporting these two packages has two advantages:

* reduce complexity of downstream packages dependency
* users don't need to explicitly add and using `Colors` and `FixedPointNumbers`

related issue:

* https://github.com/JuliaImages/ImageCore.jl/issues/74
* https://github.com/JuliaImages/Images.jl/issues/802

Other not related changes:

* add `Statistics` to [extra] section
* add `Manifest.toml` to `.gitginore`