### PR TITLE
Add NumberLike and GrayImageLike traits

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -35,9 +35,9 @@ const RealLike{T<:Real} = NumberLike{T}
 const FloatLike{T<:AbstractFloat} = RealLike{T}
 const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
 const IntegerLike{T<:Union{FixedPoint, Integer}} = RealLike{T}
-
 const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
-const GrayImageLike{BT, T<:GrayLike{BT}} = AbstractMatrix{<:RealLike{T}}
+const GrayImage{N, BT, T<:GrayLike{BT}} = AbstractArray{<:GrayLike{T}, N}
+const Gray2dImage{BT, T<:GrayLike{BT}} = GrayImage{2, BT, T}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -35,8 +35,8 @@ const RealLike{T<:Real} = NumberLike{T}
 const FloatLike{T<:AbstractFloat} = RealLike{T}
 const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
 const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
-const GenericGrayImage{N, BT, T<:GrayLike{BT}} = AbstractArray{<:GrayLike{T}, N}
-const Gray2dImage{BT, T<:GrayLike{BT}} = GenericGrayImage{2, BT, T}
+const GenericGrayImage{N, T<:GrayLike} = AbstractArray{<:GrayLike{T}, N}
+const Gray2dImage{T<:GrayLike} = GenericGrayImage{2, T}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -35,8 +35,8 @@ const RealLike{T<:Real} = NumberLike{T}
 const FloatLike{T<:AbstractFloat} = RealLike{T}
 const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
 const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
-const GrayImage{N, BT, T<:GrayLike{BT}} = AbstractArray{<:GrayLike{T}, N}
-const Gray2dImage{BT, T<:GrayLike{BT}} = GrayImage{2, BT, T}
+const GenericGrayImage{N, BT, T<:GrayLike{BT}} = AbstractArray{<:GrayLike{T}, N}
+const Gray2dImage{BT, T<:GrayLike{BT}} = GenericGrayImage{2, BT, T}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -18,7 +18,6 @@ plus(r::AbstractUnitRange, i::Integer) = broadcast(+, r, i)
 plus(a::AbstractArray, i::Integer) = a .+ i
 
 using ColorTypes: AbstractGray, TransparentGray, Color3, Transparent3
-const RealLike = Union{Real,AbstractGray}
 Color1{T} = Colorant{T,1}
 Color2{T} = Colorant{T,2}
 Color4{T} = Colorant{T,4}
@@ -29,6 +28,16 @@ Color1Array{C<:Color1,N} = AbstractArray{C,N}
 # Type that arises from reshape(reinterpret(To, A), sz):
 const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,M,From,P}}
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
+
+# delibrately not export these constants to enable extensibility for downstream packages
+const NumberLike{T<:Number} = Union{T,AbstractGray{T}}
+const RealLike{T<:Real} = NumberLike{T}
+const FloatLike{T<:AbstractFloat} = RealLike{T}
+const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
+const IntegerLike{T<:Union{FixedPoint, Integer}} = RealLike{T}
+
+const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
+const GrayImageLike{BT, T<:GrayLike{BT}} = AbstractMatrix{<:RealLike{T}}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -34,7 +34,6 @@ const NumberLike{T<:Number} = Union{T,AbstractGray{T}}
 const RealLike{T<:Real} = NumberLike{T}
 const FloatLike{T<:AbstractFloat} = RealLike{T}
 const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
-const IntegerLike{T<:Union{FixedPoint, Integer}} = RealLike{T}
 const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
 const GrayImage{N, BT, T<:GrayLike{BT}} = AbstractArray{<:GrayLike{T}, N}
 const Gray2dImage{BT, T<:GrayLike{BT}} = GrayImage{2, BT, T}

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,6 +1,6 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
-using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, IntegerLike,
+using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, 
       GrayLike, GrayImage, Gray2dImage
 
 @testset "Image traits" begin
@@ -41,7 +41,6 @@ end
         @test RealLike <: NumberLike
         @test FloatLike <: NumberLike
         @test FractionalLike <: NumberLike
-        @test IntegerLike <: NumberLike
 
         @test Number <: NumberLike
         @test Real <: NumberLike
@@ -60,7 +59,6 @@ end
     @testset "RealLike" begin
         @test FloatLike <: RealLike
         @test FractionalLike <: RealLike
-        @test IntegerLike <: RealLike
 
         @test Real <: RealLike
         @test AbstractFloat <: RealLike
@@ -106,18 +104,6 @@ end
         @test Gray{<:AbstractFloat} <: FloatLike
 
         @test !isa(oneunit(Gray), FloatLike)
-    end
-
-    @testset "IntegerLike" begin
-        @test Integer <: IntegerLike
-        @test FixedPoint <: IntegerLike
-        @test Bool <: IntegerLike
-
-        @test !(Gray <: IntegerLike)
-        @test Gray{<:Bool} <: IntegerLike
-        @test Gray{<:FixedPoint} <: IntegerLike
-
-        @test isa(oneunit(Gray), IntegerLike)
     end
 
     @testset "GrayImage" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,7 +1,7 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
 using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, IntegerLike,
-      GrayLike, GrayImageLike
+      GrayLike, GrayImage, Gray2dImage
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -120,16 +120,23 @@ end
         @test isa(oneunit(Gray), IntegerLike)
     end
 
-    @testset "GrayImageLike" begin
-        sz = (3,3)
-        @test isa(rand(Bool, sz), GrayImageLike)
-        @test isa(rand(N0f8, sz), GrayImageLike)
-        @test isa(rand(Float32, sz), GrayImageLike)
+    @testset "GrayImage" begin
+        @test Gray2dImage{Float32} == GrayImage{2, Float32}
 
-        @test isa(rand(Gray, sz), GrayImageLike)
-        @test isa(rand(Gray{Bool}, sz), GrayImageLike)
-        @test isa(rand(Gray{N0f8}, sz), GrayImageLike)
-        @test isa(rand(Gray{Float32}, sz), GrayImageLike)
+        sz = (3,3)
+        @test isa(rand(Bool, sz), Gray2dImage)
+        @test isa(rand(N0f8, sz), Gray2dImage)
+        @test isa(rand(Float32, sz), Gray2dImage)
+
+        @test isa(rand(Gray, sz), Gray2dImage)
+        @test isa(rand(Gray{Bool}, sz), Gray2dImage)
+        @test isa(rand(Gray{N0f8}, sz), Gray2dImage)
+        @test isa(rand(Gray{Float32}, sz), Gray2dImage)
+
+        foo(img::Gray2dImage) = "Generic"
+        foo(img::Gray2dImage{FixedPoint}) = "FixedPoint"
+        @test foo(rand(Gray, sz)) == "Generic"
+        @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
     end
 end
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -134,9 +134,14 @@ end
         @test isa(rand(Gray{Float32}, sz), Gray2dImage)
 
         foo(img::Gray2dImage) = "Generic"
-        foo(img::Gray2dImage{FixedPoint}) = "FixedPoint"
-        @test foo(rand(Gray, sz)) == "Generic"
+        foo(img::Gray2dImage{<:AbstractFloat}) = "AbstractFloat"
+        foo(img::Gray2dImage{<:FixedPoint}) = "FixedPoint"
+        @test foo(rand(Bool, sz)) == "Generic"
+        @test foo(rand(Gray{Bool}, sz)) == "Generic"
+        @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
+        @test foo(rand(Float32, sz)) == "AbstractFloat"
         @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
+        @test foo(rand(N0f8, sz)) == "FixedPoint"
     end
 end
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,7 +1,7 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
 using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, 
-      GrayLike, GrayImage, Gray2dImage
+      GrayLike, GenericGrayImage, Gray2dImage
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -107,7 +107,7 @@ end
     end
 
     @testset "GrayImage" begin
-        @test Gray2dImage{Float32} == GrayImage{2, Float32}
+        @test Gray2dImage{Float32} == GenericGrayImage{2, Float32}
 
         sz = (3,3)
         @test isa(rand(Bool, sz), Gray2dImage)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,5 +1,7 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
+using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, IntegerLike,
+      GrayLike, GrayImageLike
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -30,6 +32,104 @@ using Test
         assert_timedim_last(B)
         @test width(B) == 5
         @test height(B) == 3
+    end
+end
+
+@testset "*Like traits" begin
+    # delibrately written in a redundant way
+    @testset "NumberLike" begin
+        @test RealLike <: NumberLike
+        @test FloatLike <: NumberLike
+        @test FractionalLike <: NumberLike
+        @test IntegerLike <: NumberLike
+
+        @test Number <: NumberLike
+        @test Real <: NumberLike
+        @test AbstractFloat <: NumberLike
+        @test FixedPoint <: NumberLike
+        @test Integer <: NumberLike
+        @test Bool <: NumberLike
+
+        @test Gray <: NumberLike
+        @test Gray{<:AbstractFloat} <: NumberLike
+        @test Gray{<:Bool} <: NumberLike
+
+        @test isa(oneunit(Gray), NumberLike)
+    end
+
+    @testset "RealLike" begin
+        @test FloatLike <: RealLike
+        @test FractionalLike <: RealLike
+        @test IntegerLike <: RealLike
+
+        @test Real <: RealLike
+        @test AbstractFloat <: RealLike
+        @test FixedPoint <: RealLike
+        @test Integer <: RealLike
+        @test Bool <: RealLike
+
+        @test Gray{<:AbstractFloat} <: RealLike
+        @test Gray{<:Bool} <: RealLike
+        @test Gray{<:FixedPoint} <: RealLike
+
+        @test isa(oneunit(Gray), RealLike)
+    end
+
+    @testset "FractionalLike" begin
+        @test AbstractFloat <: FractionalLike
+        @test FixedPoint <: FractionalLike
+
+        @test !(Gray <: FractionalLike)
+        @test Gray{<:AbstractFloat} <: FractionalLike
+        @test Gray{<:FixedPoint} <: FractionalLike
+
+        @test isa(oneunit(Gray), FractionalLike)
+    end
+
+    @testset "GrayLike" begin
+        @test AbstractFloat <: GrayLike
+        @test FixedPoint <: GrayLike
+        @test Bool <: GrayLike
+
+        @test Gray <: GrayLike
+        @test Gray{<:AbstractFloat} <: GrayLike
+        @test Gray{<:FixedPoint} <: GrayLike
+        @test Gray{Bool} <: GrayLike
+
+        @test isa(oneunit(Gray), GrayLike)
+    end
+
+    @testset "FloatLike" begin
+        @test AbstractFloat <: FloatLike
+
+        @test !(Gray <: FloatLike)
+        @test Gray{<:AbstractFloat} <: FloatLike
+
+        @test !isa(oneunit(Gray), FloatLike)
+    end
+
+    @testset "IntegerLike" begin
+        @test Integer <: IntegerLike
+        @test FixedPoint <: IntegerLike
+        @test Bool <: IntegerLike
+
+        @test !(Gray <: IntegerLike)
+        @test Gray{<:Bool} <: IntegerLike
+        @test Gray{<:FixedPoint} <: IntegerLike
+
+        @test isa(oneunit(Gray), IntegerLike)
+    end
+
+    @testset "GrayImageLike" begin
+        sz = (3,3)
+        @test isa(rand(Bool, sz), GrayImageLike)
+        @test isa(rand(N0f8, sz), GrayImageLike)
+        @test isa(rand(Float32, sz), GrayImageLike)
+
+        @test isa(rand(Gray, sz), GrayImageLike)
+        @test isa(rand(Gray{Bool}, sz), GrayImageLike)
+        @test isa(rand(Gray{N0f8}, sz), GrayImageLike)
+        @test isa(rand(Gray{Float32}, sz), GrayImageLike)
     end
 end
 


### PR DESCRIPTION
As an alternative to https://github.com/JuliaImages/ImageCore.jl/pull/73

Currently, these kinds of traits are used throughout JuliaImages
ecosystem, adding this to ImageCore improves the consistency

These traits should not be exported to avoid potential name conflicts