### PR TITLE
add GenericImage and GenericRGBImage alias

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -35,8 +35,8 @@ const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.R
 # delibrately not export these constants to enable extensibility for downstream packages
 const NumberLike = Union{<:Number,<:AbstractGray}
 const Pixel = Union{<:Number,<:Colorant}
-const GenericImage{T<:Number, N} = AbstractArray{<:Pixel{T}, N}
-const GenericGrayImage{T<:Number, N} = AbstractArray{<:NumberLike{T}, N}
+const GenericGrayImage{T<:NumberLike,N} = AbstractArray{T,N}
+const GenericImage{T<:Pixel,N} = AbstractArray{T,N}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -33,13 +33,17 @@ const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 # delibrately not export these constants to enable extensibility for downstream packages
-const NumberLike{T<:Number} = Union{T,AbstractGray{T}}
+const PixelLike{T<:Number} = Union{T, Colorant{T}}
+const NumberLike{T<:Number} = Union{T, AbstractGray{T}}
 const RealLike{T<:Real} = NumberLike{T}
 const FloatLike{T<:AbstractFloat} = RealLike{T}
 const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
 const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
-const GenericGrayImage{N, T<:GrayLike} = AbstractArray{<:GrayLike{T}, N}
-const Gray2dImage{T<:GrayLike} = GenericGrayImage{2, T}
+const GenericImage{N, T<:Number} = AbstractArray{<:PixelLike{T}, N}
+const GenericGrayImage{N, T<:Number} = AbstractArray{<:GrayLike{T}, N}
+const GenericRGBImage{N, T<:Number} = AbstractArray{<:AbstractRGB{T}, N}
+const Gray2dImage{T<:Number} = GenericGrayImage{2, T}
+const RGB2dImage{T<:Number} = GenericRGBImage{2, T}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -33,8 +33,8 @@ const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 # delibrately not export these constants to enable extensibility for downstream packages
-const Pixel{T<:Number} = Union{T, Colorant{T}}
-const NumberLike{T<:Number} = Union{T, AbstractGray{T}}
+const NumberLike = Union{<:Number,<:AbstractGray}
+const Pixel = Union{<:Number,<:Colorant}
 const GenericImage{T<:Number, N} = AbstractArray{<:Pixel{T}, N}
 const GenericGrayImage{T<:Number, N} = AbstractArray{<:NumberLike{T}, N}
 

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -33,17 +33,11 @@ const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 # delibrately not export these constants to enable extensibility for downstream packages
-const PixelLike{T<:Number} = Union{T, Colorant{T}}
+const Pixel{T<:Number} = Union{T, Colorant{T}}
 const NumberLike{T<:Number} = Union{T, AbstractGray{T}}
-const RealLike{T<:Real} = NumberLike{T}
-const FloatLike{T<:AbstractFloat} = RealLike{T}
-const FractionalLike{T<:Union{FixedPoint, AbstractFloat}} = RealLike{T}
-const GrayLike{T<:Union{Bool, FixedPoint, AbstractFloat}} = RealLike{T}
-const GenericImage{N, T<:Number} = AbstractArray{<:PixelLike{T}, N}
-const GenericGrayImage{N, T<:Number} = AbstractArray{<:GrayLike{T}, N}
-const GenericRGBImage{N, T<:Number} = AbstractArray{<:AbstractRGB{T}, N}
-const Gray2dImage{T<:Number} = GenericGrayImage{2, T}
-const RGB2dImage{T<:Number} = GenericRGBImage{2, T}
+const GenericImage{T<:Number, N} = AbstractArray{<:Pixel{T}, N}
+const GenericGrayImage{T<:Number, N} = AbstractArray{<:NumberLike{T}, N}
+const Gray2dImage{T<:Number} = GenericGrayImage{T, 2}
 
 export
     ## Types

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -33,8 +33,8 @@ const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 # delibrately not export these constants to enable extensibility for downstream packages
-const NumberLike = Union{<:Number,<:AbstractGray}
-const Pixel = Union{<:Number,<:Colorant}
+const NumberLike = Union{Number,AbstractGray}
+const Pixel = Union{Number,Colorant}
 const GenericGrayImage{T<:NumberLike,N} = AbstractArray{T,N}
 const GenericImage{T<:Pixel,N} = AbstractArray{T,N}
 

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -37,7 +37,6 @@ const Pixel{T<:Number} = Union{T, Colorant{T}}
 const NumberLike{T<:Number} = Union{T, AbstractGray{T}}
 const GenericImage{T<:Number, N} = AbstractArray{<:Pixel{T}, N}
 const GenericGrayImage{T<:Number, N} = AbstractArray{<:NumberLike{T}, N}
-const Gray2dImage{T<:Number} = GenericGrayImage{T, 2}
 
 export
     ## Types

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,7 +1,8 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
-using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike, 
-      GrayLike, GenericGrayImage, Gray2dImage
+using ImageCore: PixelLike, NumberLike, RealLike, FloatLike, FractionalLike,
+      GrayLike,
+      GenericImage, GenericGrayImage, GenericRGBImage, Gray2dImage, RGB2dImage
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -35,8 +36,20 @@ using ImageCore: NumberLike, RealLike, FloatLike, FractionalLike,
     end
 end
 
+# delibrately written in a redundant way
 @testset "*Like traits" begin
-    # delibrately written in a redundant way
+    @testset "PixelLike" begin
+        @test NumberLike <: PixelLike
+        @test FloatLike <: PixelLike
+        @test FractionalLike <: PixelLike
+
+        @test Gray <: PixelLike
+        @test RGB <: PixelLike
+
+        @test isa(oneunit(Gray), PixelLike)
+        @test isa(RGB(1.0, 0.0, 0.0), PixelLike)
+    end
+
     @testset "NumberLike" begin
         @test RealLike <: NumberLike
         @test FloatLike <: NumberLike
@@ -104,6 +117,61 @@ end
         @test Gray{<:AbstractFloat} <: FloatLike
 
         @test !isa(oneunit(Gray), FloatLike)
+    end
+
+    @testset "GenericImage" begin
+        @test GenericGrayImage <: GenericImage
+        @test GenericRGBImage <: GenericImage
+
+        sz = (3,3)
+        @test isa(rand(Bool, sz), GenericImage)
+        @test isa(rand(N0f8, sz), GenericImage)
+        @test isa(rand(Float32, sz), GenericImage)
+
+        @test isa(rand(Gray, sz), GenericImage)
+        @test isa(rand(Gray{Bool}, sz), GenericImage)
+        @test isa(rand(Gray{N0f8}, sz), GenericImage)
+        @test isa(rand(Gray{Float32}, sz), GenericImage)
+
+        @test isa(rand(GrayA, sz), GenericImage)
+        @test isa(rand(GrayA{N0f8}, sz), GenericImage)
+        @test isa(rand(GrayA{Float32}, sz), GenericImage)
+
+        @test isa(rand(RGB, sz), GenericImage)
+        @test isa(rand(RGB{N0f8}, sz), GenericImage)
+        @test isa(rand(RGB{Float32}, sz), GenericImage)
+
+        @test isa(rand(RGBA, sz), GenericImage)
+        @test isa(rand(RGBA{N0f8}, sz), GenericImage)
+        @test isa(rand(RGBA{Float32}, sz), GenericImage)
+
+        @test isa(rand(Lab, sz), GenericImage)
+        @test isa(rand(Lab{Float32}, sz), GenericImage)
+
+        foo(img::GenericImage) = "Generic"
+        foo(img::GenericImage{N, <:AbstractFloat}) where N = "AbstractFloat"
+        foo(img::GenericImage{N, <:FixedPoint}) where N = "FixedPoint"
+        @test foo(rand(Bool, sz)) == "Generic"
+        @test foo(rand(Gray{Bool}, sz)) == "Generic"
+        @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
+        @test foo(rand(Float32, sz)) == "AbstractFloat"
+        @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
+        @test foo(rand(N0f8, sz)) == "FixedPoint"
+    end
+
+    @testset "RGBImage" begin
+        @test RGB2dImage{Float32} == GenericRGBImage{2, Float32}
+
+        sz = (3,3)
+        @test isa(rand(RGB, sz), GenericImage)
+        @test isa(rand(RGB{N0f8}, sz), GenericImage)
+        @test isa(rand(RGB{Float32}, sz), GenericImage)
+
+        foo(img::RGB2dImage) = "Generic"
+        foo(img::RGB2dImage{<:AbstractFloat}) = "AbstractFloat"
+        foo(img::RGB2dImage{<:FixedPoint}) = "FixedPoint"
+        @test foo(rand(RGB{Float32}, sz)) == "AbstractFloat"
+        @test foo(rand(RGB{N0f8}, sz)) == "FixedPoint"
     end
 
     @testset "GrayImage" begin

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -63,10 +63,6 @@ end
 
     @testset "GenericImage" begin
         @test GenericGrayImage <: GenericImage
-
-        foo(img::GenericImage) = "Generic"
-        foo(img::GenericImage{<:AbstractFloat}) = "AbstractFloat"
-        foo(img::GenericImage{<:FixedPoint}) = "FixedPoint"
         for sz in [(3, 3), (3, 3, 3)]
             @test isa(rand(Bool, sz), GenericImage)
             @test isa(rand(N0f8, sz), GenericImage)
@@ -91,21 +87,10 @@ end
 
             @test isa(rand(Lab, sz), GenericImage)
             @test isa(rand(Lab{Float32}, sz), GenericImage)
-
-            @test foo(rand(Bool, sz)) == "Generic"
-            @test foo(rand(Gray{Bool}, sz)) == "Generic"
-            @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
-            @test foo(rand(Float32, sz)) == "AbstractFloat"
-            @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
-            @test foo(rand(N0f8, sz)) == "FixedPoint"
         end
     end
 
     @testset "GrayImage" begin
-        foo(img::GenericGrayImage) = "Generic"
-        foo(img::GenericGrayImage{<:AbstractFloat}) = "AbstractFloat"
-        foo(img::GenericGrayImage{<:FixedPoint}) = "FixedPoint"
-
         for sz in [(3, 3), (3, 3, 3)]
             @test isa(rand(Bool, sz), GenericGrayImage)
             @test isa(rand(N0f8, sz), GenericGrayImage)
@@ -115,13 +100,60 @@ end
             @test isa(rand(Gray{Bool}, sz), GenericGrayImage)
             @test isa(rand(Gray{N0f8}, sz), GenericGrayImage)
             @test isa(rand(Gray{Float32}, sz), GenericGrayImage)
+        end
+    end
 
-            @test foo(rand(Bool, sz)) == "Generic"
-            @test foo(rand(Gray{Bool}, sz)) == "Generic"
-            @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
-            @test foo(rand(Float32, sz)) == "AbstractFloat"
-            @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
-            @test foo(rand(N0f8, sz)) == "FixedPoint"
+    @testset "dispatch" begin
+        begin
+            whatis(::GenericImage) = "GenericImage"
+            whatis(::GenericGrayImage) = "GenericGrayImage"
+            whatis(::GenericImage{<:AbstractRGB}) = "GenericRGBImage"
+
+            whatis(::GenericImage{<:Pixel, 2}) = "Generic2dImage"
+            whatis(::GenericGrayImage{<:NumberLike, 2}) = "Gray2dImage"
+            whatis(::GenericImage{<:AbstractRGB, 2}) = "RGB2dImage"
+
+            @test whatis(rand(Lab, 2, 2, 2)) == "GenericImage"
+
+            @test whatis(rand(Lab, 2, 2)) == "Generic2dImage"
+
+            @test whatis(rand(2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(N0f8, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Bool, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Float32, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Int64, 2, 2, 2)) == "GenericGrayImage"
+
+            @test whatis(rand(Gray, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Gray{N0f8}, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Gray{Bool}, 2, 2, 2)) == "GenericGrayImage"
+            @test whatis(rand(Gray{Float32}, 2, 2, 2)) == "GenericGrayImage"
+
+            @test whatis(rand(2, 2)) == "Gray2dImage"
+            @test whatis(rand(N0f8, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Bool, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Float32, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Int64, 2, 2)) == "Gray2dImage"
+
+            @test whatis(rand(Gray, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Gray{N0f8}, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Gray{Bool}, 2, 2)) == "Gray2dImage"
+            @test whatis(rand(Gray{Float32}, 2, 2)) == "Gray2dImage"
+
+            @test whatis(rand(RGB, 2, 2, 2)) == "GenericRGBImage"
+            @test whatis(rand(RGB{N0f8}, 2, 2, 2)) == "GenericRGBImage"
+            @test whatis(rand(RGB{Float32}, 2, 2, 2)) == "GenericRGBImage"
+
+            @test whatis(rand(BGR, 2, 2, 2)) == "GenericRGBImage"
+            @test whatis(rand(BGR{N0f8}, 2, 2, 2)) == "GenericRGBImage"
+            @test whatis(rand(BGR{Float32}, 2, 2, 2)) == "GenericRGBImage"
+
+            @test whatis(rand(RGB, 2, 2)) == "RGB2dImage"
+            @test whatis(rand(RGB{N0f8}, 2, 2)) == "RGB2dImage"
+            @test whatis(rand(RGB{Float32}, 2, 2)) == "RGB2dImage"
+
+            @test whatis(rand(BGR, 2, 2)) == "RGB2dImage"
+            @test whatis(rand(BGR{N0f8}, 2, 2)) == "RGB2dImage"
+            @test whatis(rand(BGR{Float32}, 2, 2)) == "RGB2dImage"
         end
     end
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,6 +1,6 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
-using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage, Gray2dImage
+using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -64,64 +64,65 @@ end
     @testset "GenericImage" begin
         @test GenericGrayImage <: GenericImage
 
-        sz = (3,3)
-        @test isa(rand(Bool, sz), GenericImage)
-        @test isa(rand(N0f8, sz), GenericImage)
-        @test isa(rand(Float32, sz), GenericImage)
-
-        @test isa(rand(Gray, sz), GenericImage)
-        @test isa(rand(Gray{Bool}, sz), GenericImage)
-        @test isa(rand(Gray{N0f8}, sz), GenericImage)
-        @test isa(rand(Gray{Float32}, sz), GenericImage)
-
-        @test isa(rand(GrayA, sz), GenericImage)
-        @test isa(rand(GrayA{N0f8}, sz), GenericImage)
-        @test isa(rand(GrayA{Float32}, sz), GenericImage)
-
-        @test isa(rand(RGB, sz), GenericImage)
-        @test isa(rand(RGB{N0f8}, sz), GenericImage)
-        @test isa(rand(RGB{Float32}, sz), GenericImage)
-
-        @test isa(rand(RGBA, sz), GenericImage)
-        @test isa(rand(RGBA{N0f8}, sz), GenericImage)
-        @test isa(rand(RGBA{Float32}, sz), GenericImage)
-
-        @test isa(rand(Lab, sz), GenericImage)
-        @test isa(rand(Lab{Float32}, sz), GenericImage)
-
         foo(img::GenericImage) = "Generic"
         foo(img::GenericImage{<:AbstractFloat}) = "AbstractFloat"
         foo(img::GenericImage{<:FixedPoint}) = "FixedPoint"
-        @test foo(rand(Bool, sz)) == "Generic"
-        @test foo(rand(Gray{Bool}, sz)) == "Generic"
-        @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
-        @test foo(rand(Float32, sz)) == "AbstractFloat"
-        @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
-        @test foo(rand(N0f8, sz)) == "FixedPoint"
+        for sz in [(3, 3), (3, 3, 3)]
+            @test isa(rand(Bool, sz), GenericImage)
+            @test isa(rand(N0f8, sz), GenericImage)
+            @test isa(rand(Float32, sz), GenericImage)
+
+            @test isa(rand(Gray, sz), GenericImage)
+            @test isa(rand(Gray{Bool}, sz), GenericImage)
+            @test isa(rand(Gray{N0f8}, sz), GenericImage)
+            @test isa(rand(Gray{Float32}, sz), GenericImage)
+
+            @test isa(rand(GrayA, sz), GenericImage)
+            @test isa(rand(GrayA{N0f8}, sz), GenericImage)
+            @test isa(rand(GrayA{Float32}, sz), GenericImage)
+
+            @test isa(rand(RGB, sz), GenericImage)
+            @test isa(rand(RGB{N0f8}, sz), GenericImage)
+            @test isa(rand(RGB{Float32}, sz), GenericImage)
+
+            @test isa(rand(RGBA, sz), GenericImage)
+            @test isa(rand(RGBA{N0f8}, sz), GenericImage)
+            @test isa(rand(RGBA{Float32}, sz), GenericImage)
+
+            @test isa(rand(Lab, sz), GenericImage)
+            @test isa(rand(Lab{Float32}, sz), GenericImage)
+
+            @test foo(rand(Bool, sz)) == "Generic"
+            @test foo(rand(Gray{Bool}, sz)) == "Generic"
+            @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
+            @test foo(rand(Float32, sz)) == "AbstractFloat"
+            @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
+            @test foo(rand(N0f8, sz)) == "FixedPoint"
+        end
     end
 
     @testset "GrayImage" begin
-        @test Gray2dImage{Float32} == GenericGrayImage{Float32, 2}
+        foo(img::GenericGrayImage) = "Generic"
+        foo(img::GenericGrayImage{<:AbstractFloat}) = "AbstractFloat"
+        foo(img::GenericGrayImage{<:FixedPoint}) = "FixedPoint"
 
-        sz = (3,3)
-        @test isa(rand(Bool, sz), Gray2dImage)
-        @test isa(rand(N0f8, sz), Gray2dImage)
-        @test isa(rand(Float32, sz), Gray2dImage)
+        for sz in [(3, 3), (3, 3, 3)]
+            @test isa(rand(Bool, sz), GenericGrayImage)
+            @test isa(rand(N0f8, sz), GenericGrayImage)
+            @test isa(rand(Float32, sz), GenericGrayImage)
 
-        @test isa(rand(Gray, sz), Gray2dImage)
-        @test isa(rand(Gray{Bool}, sz), Gray2dImage)
-        @test isa(rand(Gray{N0f8}, sz), Gray2dImage)
-        @test isa(rand(Gray{Float32}, sz), Gray2dImage)
+            @test isa(rand(Gray, sz), GenericGrayImage)
+            @test isa(rand(Gray{Bool}, sz), GenericGrayImage)
+            @test isa(rand(Gray{N0f8}, sz), GenericGrayImage)
+            @test isa(rand(Gray{Float32}, sz), GenericGrayImage)
 
-        foo(img::Gray2dImage) = "Generic"
-        foo(img::Gray2dImage{<:AbstractFloat}) = "AbstractFloat"
-        foo(img::Gray2dImage{<:FixedPoint}) = "FixedPoint"
-        @test foo(rand(Bool, sz)) == "Generic"
-        @test foo(rand(Gray{Bool}, sz)) == "Generic"
-        @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
-        @test foo(rand(Float32, sz)) == "AbstractFloat"
-        @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
-        @test foo(rand(N0f8, sz)) == "FixedPoint"
+            @test foo(rand(Bool, sz)) == "Generic"
+            @test foo(rand(Gray{Bool}, sz)) == "Generic"
+            @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
+            @test foo(rand(Float32, sz)) == "AbstractFloat"
+            @test foo(rand(Gray{N0f8}, sz)) == "FixedPoint"
+            @test foo(rand(N0f8, sz)) == "FixedPoint"
+        end
     end
 end
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,8 +1,6 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
-using ImageCore: PixelLike, NumberLike, RealLike, FloatLike, FractionalLike,
-      GrayLike,
-      GenericImage, GenericGrayImage, GenericRGBImage, Gray2dImage, RGB2dImage
+using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage, Gray2dImage
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -38,23 +36,17 @@ end
 
 # delibrately written in a redundant way
 @testset "*Like traits" begin
-    @testset "PixelLike" begin
-        @test NumberLike <: PixelLike
-        @test FloatLike <: PixelLike
-        @test FractionalLike <: PixelLike
+    @testset "Pixel" begin
+        @test NumberLike <: Pixel
+        @test Number <: Pixel
+        @test Gray <: Pixel
+        @test RGB <: Pixel
 
-        @test Gray <: PixelLike
-        @test RGB <: PixelLike
-
-        @test isa(oneunit(Gray), PixelLike)
-        @test isa(RGB(1.0, 0.0, 0.0), PixelLike)
+        @test isa(oneunit(Gray), Pixel)
+        @test isa(RGB(1.0, 0.0, 0.0), Pixel)
     end
 
     @testset "NumberLike" begin
-        @test RealLike <: NumberLike
-        @test FloatLike <: NumberLike
-        @test FractionalLike <: NumberLike
-
         @test Number <: NumberLike
         @test Real <: NumberLike
         @test AbstractFloat <: NumberLike
@@ -69,59 +61,8 @@ end
         @test isa(oneunit(Gray), NumberLike)
     end
 
-    @testset "RealLike" begin
-        @test FloatLike <: RealLike
-        @test FractionalLike <: RealLike
-
-        @test Real <: RealLike
-        @test AbstractFloat <: RealLike
-        @test FixedPoint <: RealLike
-        @test Integer <: RealLike
-        @test Bool <: RealLike
-
-        @test Gray{<:AbstractFloat} <: RealLike
-        @test Gray{<:Bool} <: RealLike
-        @test Gray{<:FixedPoint} <: RealLike
-
-        @test isa(oneunit(Gray), RealLike)
-    end
-
-    @testset "FractionalLike" begin
-        @test AbstractFloat <: FractionalLike
-        @test FixedPoint <: FractionalLike
-
-        @test !(Gray <: FractionalLike)
-        @test Gray{<:AbstractFloat} <: FractionalLike
-        @test Gray{<:FixedPoint} <: FractionalLike
-
-        @test isa(oneunit(Gray), FractionalLike)
-    end
-
-    @testset "GrayLike" begin
-        @test AbstractFloat <: GrayLike
-        @test FixedPoint <: GrayLike
-        @test Bool <: GrayLike
-
-        @test Gray <: GrayLike
-        @test Gray{<:AbstractFloat} <: GrayLike
-        @test Gray{<:FixedPoint} <: GrayLike
-        @test Gray{Bool} <: GrayLike
-
-        @test isa(oneunit(Gray), GrayLike)
-    end
-
-    @testset "FloatLike" begin
-        @test AbstractFloat <: FloatLike
-
-        @test !(Gray <: FloatLike)
-        @test Gray{<:AbstractFloat} <: FloatLike
-
-        @test !isa(oneunit(Gray), FloatLike)
-    end
-
     @testset "GenericImage" begin
         @test GenericGrayImage <: GenericImage
-        @test GenericRGBImage <: GenericImage
 
         sz = (3,3)
         @test isa(rand(Bool, sz), GenericImage)
@@ -149,8 +90,8 @@ end
         @test isa(rand(Lab{Float32}, sz), GenericImage)
 
         foo(img::GenericImage) = "Generic"
-        foo(img::GenericImage{N, <:AbstractFloat}) where N = "AbstractFloat"
-        foo(img::GenericImage{N, <:FixedPoint}) where N = "FixedPoint"
+        foo(img::GenericImage{<:AbstractFloat}) = "AbstractFloat"
+        foo(img::GenericImage{<:FixedPoint}) = "FixedPoint"
         @test foo(rand(Bool, sz)) == "Generic"
         @test foo(rand(Gray{Bool}, sz)) == "Generic"
         @test foo(rand(Gray{Float32}, sz)) == "AbstractFloat"
@@ -159,23 +100,8 @@ end
         @test foo(rand(N0f8, sz)) == "FixedPoint"
     end
 
-    @testset "RGBImage" begin
-        @test RGB2dImage{Float32} == GenericRGBImage{2, Float32}
-
-        sz = (3,3)
-        @test isa(rand(RGB, sz), GenericImage)
-        @test isa(rand(RGB{N0f8}, sz), GenericImage)
-        @test isa(rand(RGB{Float32}, sz), GenericImage)
-
-        foo(img::RGB2dImage) = "Generic"
-        foo(img::RGB2dImage{<:AbstractFloat}) = "AbstractFloat"
-        foo(img::RGB2dImage{<:FixedPoint}) = "FixedPoint"
-        @test foo(rand(RGB{Float32}, sz)) == "AbstractFloat"
-        @test foo(rand(RGB{N0f8}, sz)) == "FixedPoint"
-    end
-
     @testset "GrayImage" begin
-        @test Gray2dImage{Float32} == GenericGrayImage{2, Float32}
+        @test Gray2dImage{Float32} == GenericGrayImage{Float32, 2}
 
         sz = (3,3)
         @test isa(rand(Bool, sz), Gray2dImage)


### PR DESCRIPTION
Cont. #76

`GenericImage` is more general than `AbstractArray{<:Colorant}`, the latter doesn't catch `AbstractArray{<:Number}`

* PixelLike
* GenericImage
* GenericRGBImage
* RGB2dImage