### PR TITLE
add inplace operation clamp01! and clamp01nan!

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -24,7 +24,9 @@ StackedView
 
 ```@docs
 clamp01
+clamp01!
 clamp01nan
+clamp01nan!
 scaleminmax
 scalesigned
 colorsigned

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -63,7 +63,9 @@ export
     n0f16,
     # mapping values
     clamp01,
+    clamp01!,
     clamp01nan,
+    clamp01nan!,
     colorsigned,
     scaleminmax,
     scalesigned,

--- a/src/map.jl
+++ b/src/map.jl
@@ -8,22 +8,50 @@ Produce a value `y` that lies between 0 and 1, and equal to `x` when
 numeric values. For colors, this function is applied to each color
 channel separately.
 
-See also: [`clamp01nan`](@ref).
+See also: [`clamp01!`](@ref), [`clamp01nan`](@ref).
 """
 clamp01(x::Union{N0f8,N0f16}) = x
 clamp01(x::Number) = clamp(x, zero(x), one(x))
 clamp01(c::Colorant) = mapc(clamp01, c)
 
 """
+    clamp01!(array::AbstractArray)
+
+Restrict values in array to [0, 1], in-place. See also [`clamp01`](@ref).
+"""
+function clamp01!(img::AbstractArray)
+    # slgihtly faster than map!(clamp01, img, img)
+    @inbounds for i in eachindex(img)
+        img[i] = clamp01(img[i])
+    end
+    img
+end
+
+"""
     clamp01nan(x) -> y
 
 Similar to `clamp01`, except that any `NaN` values are changed to 0.
 
-See also: [`clamp01`](@ref).
+See also: [`clamp01nan!`](@ref), [`clamp01`](@ref).
 """
 clamp01nan(x) = clamp01(x)
 clamp01nan(x::AbstractFloat) = ifelse(isnan(x), zero(x), clamp01(x))
 clamp01nan(c::Colorant) = mapc(clamp01nan, c)
+
+"""
+    clamp01nan!(array::AbstractArray)
+
+Similar to `clamp01!`, except that any `NaN` values are changed to 0.
+
+See also: [`clamp01!`](@ref), [`clamp01nan`](@ref)
+"""
+function clamp01nan!(img::GenericImage)
+    # slgihtly faster than map!(clamp01nan, img, img)
+    @inbounds for i in eachindex(img)
+        img[i] = clamp01nan(img[i])
+    end
+    img
+end
 
 """
     scaleminmax(min, max) -> f

--- a/test/map.jl
+++ b/test/map.jl
@@ -25,6 +25,11 @@ using Test
         fA = f.(A)
         @test eltype(fA) == N0f8
         @test fA == [N0f8(0), N0f8(0.4), N0f8(1)]
+
+        A = [-1.2,0.4,800.3]
+        clamp01!(A)
+        @test eltype(A) == Float64
+        @test A == [0, 0.4, 1]
     end
 
     @testset "clamp01nan" begin
@@ -52,6 +57,11 @@ using Test
         fA = f.(A)
         @test eltype(fA) == N0f8
         @test fA == [N0f8(0), N0f8(0.4), N0f8(0), N0f8(0), N0f8(1), N0f8(1)]
+
+        A = [-1.2,0.4,-Inf,NaN,Inf,800.3]
+        clamp01nan!(A)
+        @test eltype(A) == Float64
+        @test A == [0, 0.4, 0, 0, 1, 1]
     end
 
     @testset "scaleminmax" begin


### PR DESCRIPTION
For `clamp` we have `clamp!`, this PR introduces a similar in-place function `clamp01!` and `clamp01nan!` for `clamp01` and `clamp01nan`

speed up : `178.559μs -> 15.619μs` for (255, 255) array

```julia
julia> function test_clamp01(n)
           m = rand(n, n) .-1
           clamp01.(m)
       end
test_clamp01 (generic function with 1 method)

julia> function test_clamp01!(n)
           m = rand(n, n) .-1
           clamp01!(m)
       end
test_clamp01! (generic function with 1 method)

julia> @benchmark rand(255, 255) .- 1
BenchmarkTools.Trial: 
  memory estimate:  1016.28 KiB
  allocs estimate:  4
  --------------
  minimum time:     90.623 μs (0.00% GC)
  median time:      415.617 μs (0.00% GC)
  mean time:        362.749 μs (12.46% GC)
  maximum time:     2.034 ms (66.25% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark test_clamp01(255)
BenchmarkTools.Trial: 
  memory estimate:  1.49 MiB
  allocs estimate:  6
  --------------
  minimum time:     124.031 μs (0.00% GC)
  median time:      621.957 μs (0.00% GC)
  mean time:        541.308 μs (13.14% GC)
  maximum time:     2.385 ms (75.51% GC)
  --------------
  samples:          9194
  evals/sample:     1

julia> @benchmark test_clamp01!(255)
BenchmarkTools.Trial: 
  memory estimate:  1016.28 KiB
  allocs estimate:  4
  --------------
  minimum time:     106.552 μs (0.00% GC)
  median time:      430.917 μs (0.00% GC)
  mean time:        378.368 μs (12.36% GC)
  maximum time:     3.114 ms (82.61% GC)
  --------------
  samples:          10000
  evals/sample:     1
```