### PR TITLE
Provide trait based opt in for Images API (take 2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ julia = ">= 1.0"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["ColorVectorSpace", "Statistics", "Test"]
+test = ["ColorVectorSpace", "Statistics", "Test", "Random"]

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -40,6 +40,8 @@ const GenericImage{T<:Pixel,N} = AbstractArray{T,N}
 
 export
     ## Types
+    HasDimNames,
+    HasProperties,
     StackedView,
     ## constants
     zeroarray,
@@ -75,6 +77,7 @@ export
     coords_spatial,
     height,
     indices_spatial,
+    namedaxes,
     nimages,
     pixelspacing,
     sdims,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,4 +1,71 @@
 """
+    HasProperties(img) -> HasProperties{::Bool}
+
+Returns the trait `HasProperties`, indicating whether `x` has `properties`
+method.
+"""
+struct HasProperties{T} end
+
+HasProperties(img::T) where T = HasProperties(T)
+
+HasProperties(::Type{T}) where T = HasProperties{false}()
+
+"""
+    HasDimNames(img) -> HasDimNames{::Bool}
+
+Returns the trait `HasDimNames`, indicating whether `x` has named dimensions.
+Types returning `HasDimNames{true}()` should also have a `names` method that
+returns a tuple of symbols for each dimension.
+"""
+struct HasDimNames{T} end
+
+HasDimNames(img::T) where T = HasDimNames(T)
+
+HasDimNames(::Type{T}) where T = HasDimNames{false}()
+
+"""
+    namedaxes(img) -> NamedTuple{names}(axes)
+
+Returns a `NamedTuple` where the names are the dimension names and each indice
+is the corresponding dimensions's axis. If `HasDimNames` is not defined for `x`
+default names are returned. `x` should have an `axes` method.
+
+```jldoctest
+julia> using ImagesAPI
+
+julia> img = reshape(1:24, 2,3,4)
+
+julia> namedaxes(img)
+```
+"""
+namedaxes(img::T) where T = namedaxes(HasDimNames(T), img)
+
+namedaxes(::HasDimNames{true}, x::T) where T = NamedTuple{names(x)}(axes(x))
+
+function namedaxes(::HasDimNames{false}, img::AbstractArray{T,N}) where {T,N}
+    NamedTuple{default_names(img)}(axes(img))
+end
+
+# returns NTuple{N,Symbol} of default names
+function default_names(img::AbstractArray{T,N}) where {T,N}
+    ntuple(i -> default_name(i), N)::NTuple{N,Symbol}
+end
+
+@inline function default_name(i::Int)
+    if i == 1
+        return :row
+    elseif i == 2
+        return :col
+    elseif i == 3
+        return :page
+    else
+        return Symbol(:dim_, i)
+    end
+end
+
+
+
+"""
     pixelspacing(img) -> (sx, sy, ...)
 
 Return a tuple representing the separation between adjacent pixels

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -31,11 +31,12 @@ is the corresponding dimensions's axis. If `HasDimNames` is not defined for `x`
 default names are returned. `x` should have an `axes` method.
 
 ```jldoctest
-julia> using ImagesAPI
+julia> using ImagesCore
 
-julia> img = reshape(1:24, 2,3,4)
+julia> img = reshape(1:24, 2,3,4);
 
 julia> namedaxes(img)
+(dim_1 = Base.OneTo(2), dim_2 = Base.OneTo(3), dim_3 = Base.OneTo(4))
 ```
 """
 namedaxes(img::T) where T = namedaxes(HasDimNames(T), img)
@@ -43,27 +44,12 @@ namedaxes(img::T) where T = namedaxes(HasDimNames(T), img)
 namedaxes(::HasDimNames{true}, x::T) where T = NamedTuple{names(x)}(axes(x))
 
 function namedaxes(::HasDimNames{false}, img::AbstractArray{T,N}) where {T,N}
-    NamedTuple{default_names(img)}(axes(img))
+    NamedTuple{default_names(Val(N))}(axes(img))
 end
 
-# returns NTuple{N,Symbol} of default names
-function default_names(img::AbstractArray{T,N}) where {T,N}
-    ntuple(i -> default_name(i), N)::NTuple{N,Symbol}
+@generated function default_names(img::Val{N}) where {N}
+    :($(ntuple(i -> Symbol(:dim_, i), N)))
 end
-
-@inline function default_name(i::Int)
-    if i == 1
-        return :row
-    elseif i == 2
-        return :col
-    elseif i == 3
-        return :page
-    else
-        return Symbol(:dim_, i)
-    end
-end
-
-
 
 """
     pixelspacing(img) -> (sx, sy, ...)

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -1,6 +1,6 @@
 using ImageCore, Colors, FixedPointNumbers, ColorVectorSpace, MappedArrays, OffsetArrays
 using Test
-using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage
+using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage, default_names
 
 @testset "Image traits" begin
     for (B, swap) in ((rand(UInt16(1):UInt16(20), 3, 5), false),
@@ -156,6 +156,16 @@ end
             @test whatis(rand(BGR{Float32}, 2, 2)) == "RGB2dImage"
         end
     end
+end
+
+@testset "Trait Interface" begin
+    # Write your own tests here.
+    img = reshape(1:24, 2,3,4)
+    @test @inferred(namedaxes(img)) == NamedTuple{default_names(img)}(axes(img))
+
+    @test @inferred(HasDimNames(img)) == HasDimNames{false}()
+
+    @test @inferred(HasProperties(img)) == HasProperties{false}()
 end
 
 nothing

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -173,7 +173,7 @@ Base.axes(rv::RowVector) = axes(rv.v)
 
 @testset "Trait Interface" begin
     img = reshape(1:24, 2,3,4)
-    @test @inferred(namedaxes(img)) == NamedTuple{default_names(img)}(axes(img))
+    @test @inferred(namedaxes(img)) == NamedTuple{(:dim_1, :dim_2, :dim_3)}(axes(img))
     @test @inferred(HasDimNames(img)) == HasDimNames{false}()
     @test @inferred(HasProperties(img)) == HasProperties{false}()
 
@@ -183,10 +183,7 @@ Base.axes(rv::RowVector) = axes(rv.v)
     @test @inferred(namedaxes(rv)) == NamedTuple{(:row,)}((Base.OneTo(10),))
 
     # default names
-    @test @inferred(default_names(rand(1))) == (:row,)
-    @test @inferred(default_names(rand(1,1))) == (:row, :col)
-    @test @inferred(default_names(rand(1,1,1))) == (:row, :col, :page)
-    @test @inferred(default_names(rand(1,1,1,1))) == (:row, :col, :page, :dim_4)
+    @test @inferred(default_names(Val(3))) == (:dim_1, :dim_2, :dim_3)
 end
 
 nothing

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -158,14 +158,35 @@ end
     end
 end
 
+struct RowVector{T,P} <: AbstractVector{T}
+    v::Vector{T}
+    p::P
+end
+
+ImageCore.HasDimNames(::Type{<:RowVector}) = HasDimNames{true}()
+
+ImageCore.HasProperties(::Type{<:RowVector}) = HasProperties{true}()
+
+Base.names(::RowVector) = (:row,)
+Base.axes(rv::RowVector) = axes(rv.v)
+
+
 @testset "Trait Interface" begin
-    # Write your own tests here.
     img = reshape(1:24, 2,3,4)
     @test @inferred(namedaxes(img)) == NamedTuple{default_names(img)}(axes(img))
-
     @test @inferred(HasDimNames(img)) == HasDimNames{false}()
-
     @test @inferred(HasProperties(img)) == HasProperties{false}()
+
+    rv = RowVector([1:10...], Dict{String,Any}())
+    @test @inferred(HasDimNames(rv)) == HasDimNames{true}()
+    @test @inferred(HasProperties(rv)) == HasProperties{true}()
+    @test @inferred(namedaxes(rv)) == NamedTuple{(:row,)}((Base.OneTo(10),))
+
+    # default names
+    @test @inferred(default_names(rand(1))) == (:row,)
+    @test @inferred(default_names(rand(1,1))) == (:row, :col)
+    @test @inferred(default_names(rand(1,1,1))) == (:row, :col, :page)
+    @test @inferred(default_names(rand(1,1,1,1))) == (:row, :col, :page, :dim_4)
 end
 
 nothing


### PR DESCRIPTION
This is following up on https://github.com/JuliaImages/Images.jl/issues/815.

The idea is to provide a bear bones interface for acting within the` Images.jl` ecosystem. It also aims to disrupt everything else as little as possible when adopted by other packages in the JuliaImages organization.