### PR TITLE
extend `float` to `Colorant`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,8 @@ PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ColorTypes = ">= 0.7.5"
-FixedPointNumbers = ">= 0.3.0"
+ColorTypes = ">= 0.8.0"
+FixedPointNumbers = ">= 0.6.1"
 MappedArrays = ">= 0.2"
 OffsetArrays = ">= 0.8"
 PaddedViews = ">= 0.4.1"
@@ -24,8 +24,9 @@ julia = ">= 1.0"
 
 [extras]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorVectorSpace", "Statistics", "Test"]
+test = ["ColorVectorSpace", "Random", "Statistics", "Test"]

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -12,6 +12,7 @@ using Colors: Fractional
 using MappedArrays: AbstractMultiMappedArray
 
 using Base: tail, @pure, Indices
+import Base: float
 
 import Graphics: width, height
 

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -141,3 +141,15 @@ converts the raw storage type of `img` to `$Tname`, without changing the color s
 
     end
 end
+
+"""
+    float(x::Colorant)
+    float(T::Type{<:Colorant})
+
+convert the storage type of pixel `x` to a floating point data type while
+preserving the `Colorant` information.
+
+If the input is Type `T`, then it is equivalent to [`floattype`](@ref).
+"""
+float(x::Colorant) = floattype(typeof(x))(x)
+float(::Type{T}) where T <: Colorant = floattype(T)

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -263,6 +263,29 @@ end
     @test eltype(float32.(a)) == Float32
     @test eltype(float64.(a)) == Float64
     @test axes(float32.(a)) == (-1:1,)
+
+    @testset "float" begin
+        # float(::Type) is equivalent to floattype
+        @test @inferred(float(RGBA{Float32})) == RGBA{Float32}
+        @test @inferred(float(BGR{N0f8})    ) == BGR{Float32}
+        @test @inferred(float(Gray{N0f8})   ) == Gray{Float32}
+
+        # `floattype(::Number)` is inconsistent to `float(::NUmber)`, see issue:
+        # https://github.com/JuliaMath/FixedPointNumbers.jl/issues/127
+        # @test @inferred(float(N0f8)         ) == Float32
+        # @test @inferred(float(Bool)         ) == Float32
+        # @test @inferred(float(Float32)      ) == Float32
+        # @test @inferred(float(Float64)      ) == Float64
+
+        @test @inferred(float(ARGB32)) == ARGB{Float32}
+        @test @inferred(float(AGray32)) == AGray{Float32}
+        @test @inferred(float(RGB24)) == RGB{Float32}
+        @test @inferred(float(Gray24)) == Gray{Float32}
+
+        # float(x::Colorant)
+        @test float(oneunit(Gray{N0f8})) == oneunit(Gray{Float32})
+        @test float(RGB(oneunit(Gray{N0f8}))) == RGB(oneunit(Gray{Float32}))
+    end
 end
 
 @testset "ambiguities" begin


### PR DESCRIPTION
With `floattype` introduced in https://github.com/JuliaGraphics/ColorTypes.jl/pull/121, we can go one step further and extend `Base.float` to `Colorant`

Instead of `floattype(eltype(img)).(img)`, we can use the simpler form `float.(img)` now