### PR TITLE
Added `findaxis`, `finddim`, and `hasdim`

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -76,6 +76,9 @@ export
     # traits
     assert_timedim_last,
     coords_spatial,
+    findaxis,
+    finddim,
+    hasdim,
     height,
     indices_spatial,
     namedaxes,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -39,9 +39,9 @@ julia> namedaxes(img)
 (:row = Base.OneTo(2), :col = Base.OneTo(3), :page = Base.OneTo(4))
 ```
 """
-namedaxes(img::T) where T = namedaxes(HasDimNames(T), img)
-namedaxes(::HasDimNames{true}, x::T) where T = NamedTuple{names(x)}(axes(x))
-namedaxes(::HasDimNames{false}, img) where {T,N} = NamedTuple{default_names(img)}(axes(img))
+namedaxes(img::T) where T = _namedaxes(HasDimNames(T), img)
+_namedaxes(::HasDimNames{true}, img) = NamedTuple{names(img)}(axes(img))
+_namedaxes(::HasDimNames{false}, img) = NamedTuple{default_names(img)}(axes(img))
 
 default_names(img::AbstractArray{T,N}) where {T,N} = ntuple(i->default_name(i), N)
 
@@ -65,7 +65,7 @@ matching name is found any empy axis (i.e. `0:0`) is returned.
 """
 @inline findaxis(A, name::Symbol) = _findaxis(namedaxes(A), name)
 function _findaxis(nt::NamedTuple{syms}, name::Symbol) where {syms}
-    if _hasdim(syms, name)
+    if __hasdim(syms, name)
         return getfield(nt, name)
     else
         return 0:-1
@@ -79,11 +79,11 @@ Returns the dimension that has the corresponding `name`. If `name` doesn't
 match any of the dimension names `0` is returned. If `img` doesn't have `names`
 then the default set of names is searched (e.g., dim_1, dim_2, ...).
 """
-@inline finddim(A::T, name::Symbol) where {T} = finddim(HasDimNames(T), A, name)
-finddim(::HasDimNames{false}, A::T, name::Symbol) where {T} = _finddim(default_names(A), name)
-finddim(::HasDimNames{true}, A::T, name::Symbol) where {T} = _finddim(names(A), name)
+@inline finddim(A::T, name::Symbol) where {T} = _finddim(HasDimNames(T), A, name)
+_finddim(::HasDimNames{false}, A::T, name::Symbol) where {T} = __finddim(default_names(A), name)
+_finddim(::HasDimNames{true}, A::T, name::Symbol) where {T} = __finddim(names(A), name)
 
-Base.@pure function _finddim(dimnames::NTuple{N,Symbol}, name::Symbol) where {N}
+Base.@pure function __finddim(dimnames::NTuple{N,Symbol}, name::Symbol) where {N}
     for i in 1:N
         getfield(dimnames, i) === name && return i
     end
@@ -96,11 +96,11 @@ end
 
 Returns `true` if `name` is present.
 """
-hasdim(x::T, name::Symbol) where {T} = hasdim(HasDimNames(T), x, name)
-hasdim(::HasDimNames{true}, x::T, name::Symbol) where {T} = _hasdim(names(x), name)
-hasdim(::HasDimNames{false}, x::T, name::Symbol) where {T} = _hasdim(default_names(x), name)
+hasdim(x::T, name::Symbol) where {T} = _hasdim(HasDimNames(T), x, name)
+_hasdim(::HasDimNames{true}, x::T, name::Symbol) where {T} = __hasdim(names(x), name)
+_hasdim(::HasDimNames{false}, x::T, name::Symbol) where {T} = __hasdim(default_names(x), name)
 
-Base.@pure function _hasdim(dimnames::Tuple{Vararg{Symbol,N}}, name::Symbol) where {N}
+Base.@pure function __hasdim(dimnames::Tuple{Vararg{Symbol,N}}, name::Symbol) where {N}
     for ii in 1:N
         getfield(dimnames, ii) === name && return true
     end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -170,10 +170,9 @@ ImageCore.HasProperties(::Type{<:RowVector}) = HasProperties{true}()
 Base.names(::RowVector) = (:row,)
 Base.axes(rv::RowVector) = axes(rv.v)
 
-
 @testset "Trait Interface" begin
     img = reshape(1:24, 2,3,4)
-    @test @inferred(namedaxes(img)) == NamedTuple{(:dim_1, :dim_2, :dim_3)}(axes(img))
+    @test @inferred(namedaxes(img)) == NamedTuple{(:row, :col, :page)}(axes(img))
     @test @inferred(HasDimNames(img)) == HasDimNames{false}()
     @test @inferred(HasProperties(img)) == HasProperties{false}()
 
@@ -188,15 +187,15 @@ Base.axes(rv::RowVector) = axes(rv.v)
 
     @test @inferred(finddim(rv, :time)) == 0
     @test @inferred(finddim(rv, :row)) == 1
-    @test @inferred(finddim(img, :dim_3)) == 3
+    @test @inferred(finddim(img, :page)) == 3
 
 
-    @test findaxis(rv, :time) == 0:0
+    @test findaxis(rv, :time) == 0:-1
     @test findaxis(rv, :row) == Base.OneTo(10)
-    @test findaxis(img, :dim_3) == Base.OneTo(4)
+    @test findaxis(img, :page) == Base.OneTo(4)
 
     # default names
-    @test @inferred(default_names(Val(3))) == (:dim_1, :dim_2, :dim_3)
+    @test @inferred(default_names(img)) == (:row, :col, :page)
 end
 
 nothing

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -182,6 +182,19 @@ Base.axes(rv::RowVector) = axes(rv.v)
     @test @inferred(HasProperties(rv)) == HasProperties{true}()
     @test @inferred(namedaxes(rv)) == NamedTuple{(:row,)}((Base.OneTo(10),))
 
+    @test @inferred(hasdim(rv, :row)) == true
+    @test @inferred(hasdim(rv, :time)) == false
+    @test @inferred(hasdim(img, :time)) == false
+
+    @test @inferred(finddim(rv, :time)) == 0
+    @test @inferred(finddim(rv, :row)) == 1
+    @test @inferred(finddim(img, :dim_3)) == 3
+
+
+    @test findaxis(rv, :time) == 0:0
+    @test findaxis(rv, :row) == Base.OneTo(10)
+    @test findaxis(img, :dim_3) == Base.OneTo(4)
+
     # default names
     @test @inferred(default_names(Val(3))) == (:dim_1, :dim_2, :dim_3)
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -169,6 +169,7 @@ ImageCore.HasProperties(::Type{<:RowVector}) = HasProperties{true}()
 
 Base.names(::RowVector) = (:row,)
 Base.axes(rv::RowVector) = axes(rv.v)
+Base.size(rv::RowVector) = size(rv.v)
 
 @testset "Trait Interface" begin
     img = reshape(1:24, 2,3,4)
@@ -176,7 +177,7 @@ Base.axes(rv::RowVector) = axes(rv.v)
     @test @inferred(HasDimNames(img)) == HasDimNames{false}()
     @test @inferred(HasProperties(img)) == HasProperties{false}()
 
-    rv = RowVector([1:10...], Dict{String,Any}())
+    rv = RowVector([1:10...], Dict{String,Any}());
     @test @inferred(HasDimNames(rv)) == HasDimNames{true}()
     @test @inferred(HasProperties(rv)) == HasProperties{true}()
     @test @inferred(namedaxes(rv)) == NamedTuple{(:row,)}((Base.OneTo(10),))
@@ -189,13 +190,17 @@ Base.axes(rv::RowVector) = axes(rv.v)
     @test @inferred(finddim(rv, :row)) == 1
     @test @inferred(finddim(img, :page)) == 3
 
-
     @test findaxis(rv, :time) == 0:-1
     @test findaxis(rv, :row) == Base.OneTo(10)
     @test findaxis(img, :page) == Base.OneTo(4)
 
     # default names
     @test @inferred(default_names(img)) == (:row, :col, :page)
+    @test @inferred(ImageCore.default_name(1)) == :row
+    @test @inferred(ImageCore.default_name(2)) == :col
+    @test @inferred(ImageCore.default_name(3)) == :page
+    @test @inferred(ImageCore.default_name(4)) == :dim_4
+
 end
 
 nothing


### PR DESCRIPTION
These are zero allocation methods that should allow easy development of methods based on the axis names. For example, defining `timedim` with this implementation would only require `timedim(x) = finddim(x, :time)`.