### PR TITLE
Adding inverse functions at 'See also' sections of some view functions

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -103,6 +103,8 @@ include("deprecations.jl")
 returns a "view" of `img` where the values are interpreted in terms of
 their raw underlying storage. For example, if `img` is an `Array{N0f8}`,
 the view will act like an `Array{UInt8}`.
+
+See also: [`normedview`](@ref)
 """
 rawview(a::AbstractArray{T}) where {T<:FixedPoint} = mappedarray(reinterpret, y->T(y,0), a)
 rawview(a::Array{T}) where {T<:FixedPoint} = reinterpret(FixedPointNumbers.rawtype(T), a)
@@ -116,6 +118,8 @@ returns a "view" of `img` where the values are interpreted in terms of
 view will act like an `Array{N0f8}`.  Supply `T` if the element
 type of `img` is `UInt16`, to specify whether you want a `N6f10`,
 `N4f12`, `N2f14`, or `N0f16` result.
+
+See also: [`rawview`](@ref)
 """
 normedview(::Type{T}, a::AbstractArray{S}) where {T<:FixedPoint,S<:Unsigned} = mappedarray(y->T(y,0),reinterpret, a)
 normedview(::Type{T}, a::Array{S}) where {T<:FixedPoint,S<:Unsigned} = reinterpret(T, a)

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -57,6 +57,8 @@ array will be in constructor-argument order, not memory order (see
 ```julia
 img = rand(RGB{N0f8}, 10, 10)
 A = channelview(img)   # a 3×10×10 array
+
+See also: [`colorview`](@ref)
 """
 channelview(A::AbstractArray{T}) where {T<:Number} = A
 channelview(A::RRPermArray{<:Colorant,<:Number}) = parent(parent(parent(A)))
@@ -96,6 +98,8 @@ interpreted in constructor-argument order, not memory order (see
 A = rand(3, 10, 10)
 img = colorview(RGB, A)
 ```
+
+See also: [`channelview`](@ref)
 """
 colorview(::Type{C}, A::AbstractArray{T}) where {C<:Colorant,T<:Number} =
     _ccolorview(ccolor_number(C, T), A)


### PR DESCRIPTION
Adding a reference to the "inverse" functions at the 'See also' section of the documentation for `colorview` <-> `channelview` and `rawview` <-> `normedview`.