### PR TITLE
Support Colors 0.10 and FixedPointNumbers 0.7. Release 0.8.7.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.8.6"
+version = "0.8.7"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -15,9 +15,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ColorTypes = "0.8"
-Colors = "0.9"
+Colors = "0.9, 0.10"
 FFTW = "0.3, 1"
-FixedPointNumbers = "0.6.1"
+FixedPointNumbers = "0.6.1, 0.7"
 Graphics = "0.4, 1.0"
 MappedArrays = "0.2"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11"


### PR DESCRIPTION
This is a "gentle" upgrade. ColorTypes 0.9 and dependents will be done in a second round.

Closes #100 
Closes #101 
