### PR TITLE
WIP: add macro channelwise

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -48,6 +48,7 @@ export
     zeroarray,
     ## functions
     # views
+    @channelwise,
     channelview,
     colorview,
     permuteddimsview,

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -404,4 +404,13 @@ end
 
 end
 
+@testset "channelwise" begin
+x = rand(RGB{Float32}, 4, 4)
+y = rand(RGB{Float32}, 4, 4)
+z = @channelwise x + y
+@test z == channelview(x) + channelview(y)
+@test z == @channelwise copy(x) + copy(y) # channelwise the result of function call
+# TODO: channelwise the argument of function call?
+end
+
 nothing


### PR DESCRIPTION
This is the very draft of my `@channelwise` idea in https://github.com/JuliaImages/Images.jl/issues/817

The basic idea is to insert a `channelview` to each possible argument. For example, `@channelwise euclidean(x, y)` is equivalent to `euclidean(channelview(x), channelview(y))`.

I'm not familiar with the macro mechanism at present, the current code doesn't work properly. (I guess I need to quote the codes in `has_channel` for `Symbol` and `Expr`)