### PR TITLE
make FFTW a soft dependence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,18 +5,17 @@ version = "0.8.7"
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Graphics = "a2bd30eb-e257-5431-a919-1863eab51364"
 MappedArrays = "dbb5928d-eab1-5f90-85c2-b9b0edb7c900"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ColorTypes = "0.8"
 Colors = "0.9, 0.10"
-FFTW = "0.3, 1"
 FixedPointNumbers = "0.6.1, 0.7"
 Graphics = "0.4, 1.0"
 MappedArrays = "0.2"
@@ -27,9 +26,10 @@ julia = "1"
 
 [extras]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorVectorSpace", "Random", "Statistics", "Test"]
+test = ["ColorVectorSpace", "FFTW", "Random", "Statistics", "Test"]

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -3,6 +3,7 @@ VERSION < v"0.7.0-beta2.199" && __precompile__()
 module ImageCore
 
 using Reexport
+using Requires
 @reexport using Colors
 @reexport using FixedPointNumbers
 using MappedArrays, PaddedViews, Graphics
@@ -93,7 +94,6 @@ include("stackedviews.jl")
 include("convert_reinterpret.jl")
 include("traits.jl")
 include("map.jl")
-include("functions.jl")
 include("show.jl")
 include("deprecations.jl")
 
@@ -146,6 +146,10 @@ function Base.transpose(a::AbstractVector{C}) where C<:Colorant
     outr = reshape(out, ind)
     copy!(outr, a)
     out
+end
+
+function __init__()
+    @require FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341" include("functions.jl")
 end
 
 end ## module

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,4 +1,4 @@
-import FFTW: fft, rfft, plan_fft, plan_rfft
+import .FFTW: fft, rfft, plan_fft, plan_rfft
 
 # It's better not to define fft on Colorant arrays, because keeping
 # track of the color dimension and the fft-dims is prone to omissions

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,6 +1,4 @@
-using ImageCore, Colors, FixedPointNumbers
 using FFTW
-using Test
 
 @testset "functions" begin
     ag = rand(Gray{Float32}, 4, 5)


### PR DESCRIPTION
This can reduce loading time ~50%:

* This PR: 1.280366 seconds (1.50 M allocations: 87.844 MiB, 0.82% gc time)
* Before: 2.707802 seconds (6.70 M allocations: 350.225 MiB, 1.67% gc time)

I do have two questions wrt `Requires`:

* will indirect loading of `FFTW`( e.g. `using ImageFiltering`) trigger this?
* does loading order matters? (e.g., `using ImageCore; using FFTW` vs `using FFTW; using ImageCore`)

My understanding is yes to both.