### PR TITLE
Add deprecations for RGB1 and RGB4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -4,8 +4,11 @@ module ImageCore
 
 using Reexport
 using Requires
-@reexport using Colors
 @reexport using FixedPointNumbers
+@reexport using Colors
+Base.@deprecate_binding RGB1 XRGB
+Base.@deprecate_binding RGB4 RGBX
+
 using MappedArrays, PaddedViews, Graphics
 using OffsetArrays # for show.jl
 using .ColorTypes: colorant_string


### PR DESCRIPTION
These don't propagate with reexport