### PR TITLE
Fix the deprecation warning for RGBX/XRGB

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.8.9"
+version = "0.8.10"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -6,8 +6,15 @@ using Reexport
 using Requires
 @reexport using FixedPointNumbers
 @reexport using Colors
-Base.@deprecate_binding RGB1 XRGB
-Base.@deprecate_binding RGB4 RGBX
+if isdefined(ColorTypes, :XRGB) && isdefined(ColorTypes, :RGB1)
+    Base.@deprecate_binding RGB1 XRGB
+    Base.@deprecate_binding RGB4 RGBX
+end
+# backward compatibility for ColorTypes < v0.9
+if !isdefined(ColorTypes, :XRGB)
+    const XRGB = RGB1
+    const RGBX = RGB4
+end
 
 using MappedArrays, PaddedViews, Graphics
 using OffsetArrays # for show.jl
@@ -42,12 +49,6 @@ const NumberLike = Union{Number,AbstractGray}
 const Pixel = Union{Number,Colorant}
 const GenericGrayImage{T<:NumberLike,N} = AbstractArray{T,N}
 const GenericImage{T<:Pixel,N} = AbstractArray{T,N}
-
-# backward compatibility for ColorTypes < v0.9
-if !isdefined(ColorTypes, :XRGB)
-    const XRGB = RGB1
-    const RGBX = RGB4
-end
 
 export
     ## Types


### PR DESCRIPTION
Since we don't require ColorTypes 0.9, anyone who didn't update to the latest would have gotten an error. Sadly, release 0.8.9 will be buggy, so let's get this out ASAP.