### PR TITLE
deprecate permuteddimsview

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -138,17 +138,6 @@ normedview(::Type{T}, a::AbstractArray{T}) where {T<:Normed} = a
 normedview(a::AbstractArray{UInt8}) = normedview(N0f8, a)
 normedview(a::AbstractArray{T}) where {T<:Normed} = a
 
-"""
-    permuteddimsview(A, perm)
-
-returns a "view" of `A` with its dimensions permuted as specified by
-`perm`. This is like `permutedims`, except that it produces a view
-rather than a copy of `A`; consequently, any manipulations you make to
-the output will be mirrored in `A`. Compared to the copy, the view is
-much faster to create, but generally slower to use.
-"""
-permuteddimsview(A, perm) = Base.PermutedDimsArrays.PermutedDimsArray(A, perm)
-
 # PaddedViews support
 # This make sure Colorants as `fillvalue` are correctly filled, for example, let
 # `PaddedView(ARGB(0, 0, 0, 0), img)` correctly filled with transparent color even when

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -47,3 +47,6 @@ function convert(::Type{OffsetArray{Cdest,n,A}}, img::AbstractArray{Csrc,n}) whe
 end
 
 convert(::Type{OffsetArray{Cdest,n,A}}, img::OffsetArray{Cdest,n,A}) where {Cdest<:Colorant,n, A <:AbstractArray} = img
+
+# a perhaps "permanent" deprecation
+Base.@deprecate_binding permuteddimsview PermutedDimsArray

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,10 @@
+@testset "permuteddimsview" begin
+    a = [1 3; 2 4]
+    v = permuteddimsview(a, (1,2))
+    @test v == a
+    v = permuteddimsview(a, (2,1))
+    @test v == a'
+    a = rand(3,7,5)
+    v = permuteddimsview(a, (2,3,1))
+    @test v == permutedims(a, (2,3,1))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ include("traits.jl")
 include("map.jl")
 include("functions.jl")
 include("show.jl")
+include("deprecations.jl")
 
 # To ensure our deprecations work and don't break code
 include("deprecated.jl")

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -10,8 +10,8 @@ using ImageCore: Pixel, NumberLike, GenericImage, GenericGrayImage, default_name
                       (rand(UInt32, 3, 5), false),
                       (view(rand(3, 2, 5), :, 1, :), false),
                       (OffsetArray(rand(3, 5), -1:1, -2:2), false),
-                      (permuteddimsview(rand(5, 3), (2, 1)), true),
-                      (mappedarray(identity, permuteddimsview(rand(5, 3), (2, 1))), true),
+                      (PermutedDimsArray(rand(5, 3), (2, 1)), true),
+                      (mappedarray(identity, PermutedDimsArray(rand(5, 3), (2, 1))), true),
                       (colorview(RGB, zeros(3, 5), zeroarray, zeros(3, 5)), false))
         @test pixelspacing(B) == (1,1)
         if !isa(B, SubArray)

--- a/test/views.jl
+++ b/test/views.jl
@@ -38,17 +38,6 @@ end
     @test normedview(N0f8, v) === v
 end
 
-@testset "permuteddimsview" begin
-    a = [1 3; 2 4]
-    v = permuteddimsview(a, (1,2))
-    @test v == a
-    v = permuteddimsview(a, (2,1))
-    @test v == a'
-    a = rand(3,7,5)
-    v = permuteddimsview(a, (2,3,1))
-    @test v == permutedims(a, (2,3,1))
-end
-
 @testset "StackedView" begin
     for (A, B, T) = (([1 3;2 4], [-1 -5; -2 -3], Int),
                      ([1 3;2 4], [-1.0 -5.0; -2.0 -3.0], Float64))


### PR DESCRIPTION
Not sure if deprecating this is wanted, but this name doesn't give anything useful except the "view" hint in its name.

closes https://github.com/JuliaImages/juliaimages.github.io/issues/12