### PR TITLE
Missing closing ``` in a docstring

### DIFF
--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -57,6 +57,7 @@ array will be in constructor-argument order, not memory order (see
 ```julia
 img = rand(RGB{N0f8}, 10, 10)
 A = channelview(img)   # a 3×10×10 array
+```
 
 See also: [`colorview`](@ref)
 """


### PR DESCRIPTION
I noticed in the doc of [ImageCore.channelview](https://juliaimages.org/ImageCore.jl/stable/reference/#ImageCore.channelview)
that the code block of the example was not being closed.