### PR TITLE
Deprecate eltype-specific convert methods

### DIFF
--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -59,59 +59,6 @@ ccolor_number(::Type{CV}, ::Type{T}) where {CV<:Colorant,T<:Number} =
 ccolor_number(::Type{CV}, ::Type{CVT}, ::Type{T}) where {CV,CVT<:Number,T} = CV # form 1
 ccolor_number(::Type{CV}, ::Type{Any}, ::Type{T}) where {CV<:Colorant,T} = CV{T} # form 2
 
-
-### convert
-#
-# The main contribution here is "concretizing" the colorant type: allow
-#    convert(RGB, a)
-# rather than requiring
-#    convert(RGB{N0f8}, a)
-# Where possible the raw element type of the source is retained.
-Base.convert(::Type{Array{C}},   img::Array{C,n}) where {C<:Color1,n} = img
-Base.convert(::Type{Array{C,n}}, img::Array{C,n}) where {C<:Color1,n} = img
-Base.convert(::Type{Array{C}},   img::Array{C,n}) where {C<:Colorant,n} = img
-Base.convert(::Type{Array{C,n}}, img::Array{C,n}) where {C<:Colorant,n} = img
-
-function Base.convert(::Type{Array{Cdest}},
-                      img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
-    convert(Array{Cdest,n}, img)
-end
-
-function Base.convert(::Type{Array{Cdest,n}},
-                      img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
-    copyto!(Array{ccolor(Cdest, Csrc)}(undef, size(img)), img)
-end
-
-function Base.convert(::Type{Array{Cdest}},
-                      img::BitArray{n}) where {Cdest<:Color1,n}
-    convert(Array{Cdest,n}, img)
-end
-
-function Base.convert(::Type{Array{Cdest}},
-                      img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
-    convert(Array{Cdest,n}, img)
-end
-
-function Base.convert(::Type{Array{Cdest,n}},
-                      img::BitArray{n}) where {Cdest<:Color1,n}
-    copyto!(Array{ccolor(Cdest, Gray{Bool})}(undef, size(img)), img)
-end
-
-function Base.convert(::Type{Array{Cdest,n}},
-                      img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
-    copyto!(Array{ccolor(Cdest, Gray{T})}(undef, size(img)), img)
-end
-
-function Base.convert(::Type{OffsetArray{Cdest,n,A}},
-                      img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n, A <:AbstractArray,Csrc<:Colorant}
-    copyto!(OffsetArray{ccolor(Cdest, Csrc)}(undef, axes(img)),img)
-end
-
-function Base.convert(::Type{OffsetArray{C,n,A}},
-                      img::AbstractArray{C,n}) where {C<:Colorant,n, A <:AbstractArray}
-    img
-end
-
 # for docstrings in the operations below
 shortname(::Type{T}) where {T<:FixedPoint} = (io = IOBuffer(); FixedPointNumbers.showtype(io, T); String(take!(io)))
 shortname(::Type{T}) where {T} = string(T)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -22,3 +22,28 @@ end
 ColorView(parent::AbstractArray) = error("must specify the colortype, use colorview(C, A)")
 
 Base.@deprecate_binding squeeze1 true
+
+import Base: convert
+
+function cname(::Type{C}) where C
+    io = IOBuffer()
+    ColorTypes.colorant_string_with_eltype(io, C)
+    return String(take!(io))
+end
+
+function convert(::Type{Array{Cdest}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
+    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+    Cdest.(img)
+end
+
+function convert(::Type{Array{Cdest}}, img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
+    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+    Cdest.(img)
+end
+
+function convert(::Type{OffsetArray{Cdest,n,A}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n, A <:AbstractArray,Csrc<:Colorant}
+    Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+    Cdest.(img)
+end
+
+convert(::Type{OffsetArray{Cdest,n,A}}, img::OffsetArray{Cdest,n,A}) where {Cdest<:Colorant,n, A <:AbstractArray} = img

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,86 @@
+using ImageCore, Colors, FixedPointNumbers, OffsetArrays
+using Test, Random
+
+@testset "convert" begin
+    a = [RGB(1,0,0) RGB(0,0,1);
+         RGB(0,1,0) RGB(1,1,1)]
+    c = @inferred(convert(Array{BGR}, a))
+    @test eltype(c) == BGR{N0f8}
+    c = @inferred(convert(Array{BGR{Float32}}, a))
+    @test eltype(c) == BGR{Float32}
+    c = @inferred(convert(Array{Lab}, a))
+    @test eltype(c) == Lab{Float32}
+    for a in (rand(Float32, (4,5)),
+              bitrand(4,5))
+        b = @inferred(convert(Array{Gray}, a))
+        @test eltype(b) == Gray{eltype(a)}
+        b = @inferred(convert(Array{Gray{N0f8}}, a))
+        @test eltype(b) == Gray{N0f8}
+    end
+
+    # Gray images wrapped by an OffsetArray.
+    A = rand(8,8)
+    for img in ( Gray.(A),
+                 Gray.(N0f8.(A)),
+                 Gray.(N0f16.(A)) )
+        imgo = OffsetArray(img, -2, -1)
+        s = @inferred(convert(OffsetArray{Gray{Float32},2,Array{Gray{Float32}}},imgo))
+        @test eltype(s) == Gray{Float32}
+        @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+    end
+
+    for img in ( Gray.(A),
+                 Gray.(N0f8.(A)),
+                 Gray.(N0f16.(A)) )
+        imgo = OffsetArray(img, -2, -1)
+        s = @inferred(convert(OffsetArray{Gray{N0f8},2,Array{Gray{N0f8}}},imgo))
+        @test eltype(s) == Gray{N0f8}
+        @test s isa OffsetArray{Gray{N0f8},2,Array{Gray{N0f8},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+    end
+
+    for img in ( Gray.(A),
+                 Gray.(N0f8.(A)),
+                 Gray.(N0f16.(A)) )
+        imgo = OffsetArray(img, -2, -1)
+        s = @inferred(convert(OffsetArray{Gray{N0f16},2,Array{Gray{N0f16}}},imgo))
+        @test eltype(s) == Gray{N0f16}
+        @test s isa OffsetArray{Gray{N0f16},2,Array{Gray{N0f16},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+    end
+
+    # Color images wrapped by an OffsetArray.
+    A = rand(RGB{Float32},8,8)
+    for img in ( A,
+                 n0f8.(A),
+                 n6f10.(A),
+                 n4f12.(A),
+                 n2f14.(A),
+                 n0f16.(A))
+        imgo = OffsetArray(img, -2, -1)
+        s = @inferred(convert(OffsetArray{RGB{N0f8},2,Array{RGB{N0f8}}},imgo))
+        @test eltype(s) == RGB{N0f8}
+        @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+    end
+
+    A = rand(RGB{Float32},8,8)
+    for img in ( A,
+                 n0f8.(A),
+                 n6f10.(A),
+                 n4f12.(A),
+                 n2f14.(A),
+                 n0f16.(A))
+        imgo = OffsetArray(img, -2, -1)
+        s = @inferred(convert(OffsetArray{RGB{Float32},2,Array{RGB{Float32}}},imgo))
+        @test eltype(s) == RGB{Float32}
+        @test s isa OffsetArray{RGB{Float32},2,Array{RGB{Float32},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,9 @@ include("map.jl")
 include("functions.jl")
 include("show.jl")
 
+# To ensure our deprecations work and don't break code
+include("deprecated.jl")
+
 # run these last
 isCI = haskey(ENV, "CI") || get(ENV, "JULIA_PKGEVAL", false)
 if Base.JLOptions().can_inline == 1 && !isCI


### PR DESCRIPTION
These are technically pirating and cause quite a few invalidations. Now that we have generic broadcasting they are no longer necessary. xref https://github.com/JuliaGraphics/ColorTypes.jl/pull/196.

This first submission of the PR does not fix depwarns in the tests, because I want to see if everything passes before doing so.

Also xref #122. We should merge these two at around the same time, along with any other deprecations, to reduce the number of times we annoy users.