### PR TITLE
Added channelwise macro to be used with functions

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -61,6 +61,7 @@ export
     zeroarray,
     ## functions
     # views
+    @channelwise,
     channelview,
     colorview,
     permuteddimsview,

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -186,6 +186,27 @@ extractchannels(c::TransparentGray) = (gray(c), alpha(c))
 extractchannels(c::Color3)          = (comp1(c), comp2(c), comp3(c))
 extractchannels(c::Transparent3)    = (comp1(c), comp2(c), comp3(c), alpha(c))
 
+
+
+function _channelview(ex::Expr)
+    args = [ex.args[i] for i = 1:length(ex.args)]
+    for j = 1:length(args)
+        if isa(eval(ex.args[j]), AbstractArray)
+            ex.args[j] = channelview(eval(ex.args[j]))
+        else
+            ex.args[j]
+        end
+    end
+    return ex
+
+end
+
+macro channelwise(ex)
+    _channelview(ex)
+end
+
+
+
 ## Tuple & indexing utilities
 
 _size(A::AbstractArray) = map(length, axes(A))

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -278,6 +278,25 @@ end
     end
 end
 
+
+@testset "channelwise" begin
+    x = rand(RGB{Float32}, 4, 4)
+    y = rand(RGB{Float32}, 4, 4)
+
+    z = channelview(x) + channelview(y)
+    z1 = @channelwise x + y
+
+    @test z == z1
+
+    z = euclidean(channelview(x), channelview(y))
+    z1 = @channelwise euclidean(x, y)
+
+    @test z == z1
+end
+
+
+
+
 @testset "RGB, HSV, etc" begin
     for T in (RGB, BGR, XRGB, RGBX, HSV, Lab, XYZ)
         a0 = [0.1 0.2 0.3; 0.4 0.5 0.6]'


### PR DESCRIPTION
Added the macro for channelwise to implement channelview on parameters without needing to call the built in function. Can also be used with functions e.g. channelwise euclidean(x, y). Added a couple testing lines in colorchannels in test directory.