### PR TITLE
Restrict depwarn to non-concrete color types

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -31,21 +31,24 @@ function cname(::Type{C}) where C
     return String(take!(io))
 end
 
+const _explain =
+"""will soon switch to returning an array with non-concrete element type, which adds flexibility but
+   with great cost to performance. To maintain the current behavior, use """
 function convert(::Type{Array{Cdest}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
     if isconcretetype(Cdest)
         # This mimics the Base implementation
         return img isa Array{Cdest} ? img : Array{Cdest}(img)
     end
-    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
-    Cdest.(img)
+    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` $_explain $(cname(Cdest)).(img) instead", :convert)
+    convert(Array, Cdest.(img))
 end
 
 function convert(::Type{Array{Cdest}}, img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
     if isconcretetype(Cdest)
         return img isa Array{Cdest} ? img : Array{Cdest}(img)
     end
-    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
-    Cdest.(img)
+    Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` $_explain $(cname(Cdest)).(img) instead", :convert)
+    convert(Array, Cdest.(img))
 end
 
 function convert(::Type{OffsetArray{Cdest,n,A}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n, A <:AbstractArray,Csrc<:Colorant}
@@ -53,11 +56,11 @@ function convert(::Type{OffsetArray{Cdest,n,A}}, img::AbstractArray{Csrc,n}) whe
         return img isa OffsetArray{Cdest,n,A} ? img : (img isa OffsetArray ? OffsetArray(A(Cdest.(parent(img))), axes(img)) : OffsetArray(A(Cdest.(img)), axes(img)))
     end
     if img isa OffsetArray
-        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` $_explain $(cname(Cdest)).(img) instead", :convert)
     else
-        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use OffsetArray($(cname(Cdest)).(img)) instead", :convert)
+        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` $_explain OffsetArray($(cname(Cdest)).(img)) instead", :convert)
     end
-    Cdest.(img)
+    OffsetArray(Cdest.(img), axes(img))
 end
 
 convert(::Type{OffsetArray{Cdest,n,A}}, img::OffsetArray{Cdest,n,A}) where {Cdest<:Colorant,n, A <:AbstractArray} = img

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -32,17 +32,31 @@ function cname(::Type{C}) where C
 end
 
 function convert(::Type{Array{Cdest}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n,Csrc<:Colorant}
+    if isconcretetype(Cdest)
+        # This mimics the Base implementation
+        return img isa Array{Cdest} ? img : Array{Cdest}(img)
+    end
     Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
     Cdest.(img)
 end
 
 function convert(::Type{Array{Cdest}}, img::AbstractArray{T,n}) where {Cdest<:Color1,n,T<:Real}
+    if isconcretetype(Cdest)
+        return img isa Array{Cdest} ? img : Array{Cdest}(img)
+    end
     Base.depwarn("`convert(Array{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
     Cdest.(img)
 end
 
 function convert(::Type{OffsetArray{Cdest,n,A}}, img::AbstractArray{Csrc,n}) where {Cdest<:Colorant,n, A <:AbstractArray,Csrc<:Colorant}
-    Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+    if isconcretetype(Cdest) && isconcretetype(A) && eltype(A) === Cdest
+        return img isa OffsetArray{Cdest,n,A} ? img : (img isa OffsetArray ? OffsetArray(A(Cdest.(parent(img))), axes(img)) : OffsetArray(A(Cdest.(img)), axes(img)))
+    end
+    if img isa OffsetArray
+        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use $(cname(Cdest)).(img) instead", :convert)
+    else
+        Base.depwarn("`convert(OffsetArray{$(cname(Cdest))}, img)` is deprecated, use OffsetArray($(cname(Cdest)).(img)) instead", :convert)
+    end
     Cdest.(img)
 end
 

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -147,6 +147,8 @@ end
     @test eltype(c) == BGR{N0f8}
     c = @inferred(broadcast(BGR{Float32}, a))
     @test eltype(c) == BGR{Float32}
+    c = @inferred(convert(Array{BGR{Float32}}, a))   # convert(Array{C}, a) where C is a concrete colortype is not deprecated
+    @test eltype(c) == BGR{Float32}
     c = @inferred(broadcast(Lab, a))
     @test eltype(c) == Lab{Float32}
     for a in (rand(Float32, (4,5)),
@@ -154,6 +156,8 @@ end
         b = @inferred(broadcast(Gray, a))
         @test eltype(b) == Gray{eltype(a)}
         b = @inferred(broadcast(Gray{N0f8}, a))
+        @test eltype(b) == Gray{N0f8}
+        b = @inferred(convert(Array{Gray{N0f8}}, a))
         @test eltype(b) == Gray{N0f8}
     end
 
@@ -164,6 +168,11 @@ end
                  Gray.(N0f16.(A)) )
         imgo = OffsetArray(img, -2, -1)
         s = @inferred(broadcast(Gray{Float32}, imgo))
+        @test eltype(s) == Gray{Float32}
+        @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+        s = @inferred(convert(OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}},imgo))
         @test eltype(s) == Gray{Float32}
         @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
@@ -202,6 +211,11 @@ end
                  n0f16.(A))
         imgo = OffsetArray(img, -2, -1)
         s = @inferred(broadcast(RGB{N0f8}, imgo))
+        @test eltype(s) == RGB{N0f8}
+        @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
+        @test permutedims(permutedims(s,(2,1)),(2,1)) == s
+        @test axes(s) === axes(imgo)
+        s = @inferred(convert(OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}},imgo))
         @test eltype(s) == RGB{N0f8}
         @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,7 +1,8 @@
 using ImageCore, Colors, FixedPointNumbers, OffsetArrays
 using Test, Random
 
-@testset "convert" begin
+@testset "convert (deprecations)" begin
+    @info "Deprecation warnings are expected"
     a = [RGB(1,0,0) RGB(0,0,1);
          RGB(0,1,0) RGB(1,1,1)]
     c = @inferred(convert(Array{BGR}, a))


### PR DESCRIPTION
The only behavior that's changing is `convert(Array{RGB}, A)`, which will no longer choose a numeric type `T` for `RGB{T}`---instead it will literally be an `Array{RGB}`. But `convert(Array{RGB{Float32}}, A)` will continue to work as before (it will just rely on the Base machinery), so don't issue a warning.
