### PR TITLE
Add a few precompiles

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -168,6 +168,11 @@ function Base.transpose(a::AbstractVector{C}) where C<:Colorant
     out
 end
 
+if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
+    include("precompile.jl")
+    _precompile_()
+end
+
 function __init__()
     @require FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341" include("functions.jl")
 end

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -39,8 +39,8 @@ _len(::Type{C}, ::Type{T}) where {C,T} = sizeof(C) ÷ sizeof(T)
 # We have to distinguish two forms of call:
 #   form 1: reinterpretc(RGB{N0f8}, img)
 #   form 2: reinterpretc(RGB, img)
-function reinterpretc(::Type{CV}, a::AbstractArray{T}) where {CV<:Colorant,T<:Number}
-    @noinline throwdm(::Type{C}, ind1) where C =
+function reinterpretc(CV::Type{<:Colorant}, a::AbstractArray{T}) where T<:Number # {CV<:Colorant,T<:Number}
+    @noinline throwdm(C::Type, ind1) =
         throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))
     CVT = ccolor_number(CV, T)
     if samesize(CVT, T)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,58 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
+    pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
+    cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
+    dims  = (1, 2, 3, 4)
+
+    for T in eltypes
+        @assert precompile(clamp01, (T,))
+        @assert precompile(clamp01nan, (T,))
+        @assert precompile(scaleminmax, (T, T))
+        @assert precompile(scalesigned, (T,))
+        @assert precompile(scalesigned, (T,T,T))
+        for C in pctypes
+            @assert precompile(clamp01, (C{T},))
+            @assert precompile(clamp01nan, (C{T},))
+            @assert precompile(colorsigned, (C{T},C{T}))
+        end
+    end
+    for C in cctypes
+        @assert precompile(clamp01, (C,))
+        @assert precompile(clamp01nan, (C,))
+        @assert precompile(colorsigned, (C,C))
+end
+    for n in dims
+        for T in eltypes
+            @assert precompile(rawview, (Array{T,n},))
+        end
+        @assert precompile(normedview, (Array{UInt8,n},))
+        @assert precompile(normedview, (Type{N0f8}, Array{UInt8,n}))
+        @assert precompile(normedview, (Type{N0f16}, Array{UInt16,n}))
+    end
+    for T in eltypes
+        for n in dims
+            for C in pctypes
+                @assert precompile(colorview, (Type{C}, Array{T,n}))
+                @assert precompile(colorview, (Type{C{T}}, Array{T,n}))
+                if T<:FixedPoint
+                    R = FixedPointNumbers.rawtype(T)
+                    RA = Base.ReinterpretArray{T,n,R,Array{R,n}}
+                    precompile(colorview, (Type{C}, RA))
+                    precompile(colorview, (Type{C{T}}, RA))
+                    precompile(reinterpretc, (Type{C{T}}, RA))
+                end
+                @assert precompile(channelview, (Array{C{T},n},))
+            end
+            for C in cctypes
+                @assert precompile(colorview, (Type{C}, Array{T,n}))
+                if T<:FixedPoint
+                    R = FixedPointNumbers.rawtype(T)
+                    RA = Base.ReinterpretArray{T,n,R,Array{R,n}}
+                    precompile(colorview, (Type{C}, RA))
+                end
+                @assert precompile(channelview, (Array{C,n},))
+            end
+        end
+    end
+end


### PR DESCRIPTION
On these low-level packages, inference is not a big burden but having these here makes it easier for other packages to rely on them for their precompilation. Drops the time for first `colorview(RGB, ::Array{Float64,3})` from about 30ms to 15ms on my machine (for a small array so that it's compile-dominated).