### PR TITLE
Use Julia 1.6's new reinterpretarray machinery

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -43,7 +43,11 @@ ColorA{N,C,T} = ColorAlpha{C,T,N}
 const NonparametricColors = Union{RGB24,ARGB32,Gray24,AGray32}
 Color1Array{C<:Color1,N} = AbstractArray{C,N}
 # Type that arises from reshape(reinterpret(To, A), sz):
-const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,M,From,P}}
+if VERSION >= v"1.6.0-DEV.1083"
+    const RRArray{To,From,M,P} = Base.ReinterpretArray{To,M,From,P,true}
+else
+    const RRArray{To,From,N,M,P} = Base.ReshapedArray{To,N,Base.ReinterpretArray{To,M,From,P}}
+end
 const RGArray = Union{Base.ReinterpretArray{<:AbstractGray,M,<:Number,P}, Base.ReinterpretArray{<:Number,M,<:AbstractGray,P}} where {M,P}
 
 # delibrately not export these constants to enable extensibility for downstream packages

--- a/src/convert_reinterpret.jl
+++ b/src/convert_reinterpret.jl
@@ -2,61 +2,67 @@
 
 @pure samesize(::Type{T}, ::Type{S}) where {T,S} = sizeof(T) == sizeof(S)
 
-## Color->Color
-# function reinterpretc(::Type{CV1}, a::Array{CV2,1}) where {CV1<:Colorant,CV2<:Colorant}
-#     CV = ccolor(CV1, CV2)
-#     l = (length(a)*sizeof(CV2))÷sizeof(CV1)
-#     l*sizeof(CV1) == length(a)*sizeof(CV2) || throw(ArgumentError("sizes are incommensurate"))
-#     reshape(reinterpret(CV, a), (l,))
-# end
-function reinterpretc(::Type{CV1}, a::AbstractArray{CV2}) where {CV1<:Colorant,CV2<:Colorant}
-    CV = ccolor(CV1, CV2)
-    if samesize(CV, CV2)
-        return reshape(reinterpret(CV, a), size(a))
+if VERSION >= v"1.6.0-DEV.1083"
+    reinterpretc(::Type{T}, a::AbstractArray) where T = reinterpret(reshape, ccolor_number(T, eltype(a)), a)
+    reinterpretc(::Type{T}, a::Base.ReinterpretArray{S,N,T,AA,true}) where {T,S,N,AA<:AbstractArray{T}} = parent(a)
+else
+    # Color->Color
+    function reinterpretc(::Type{CV1}, a::Array{CV2,1}) where {CV1<:Colorant,CV2<:Colorant}
+        CV = ccolor(CV1, CV2)
+        l = (length(a)*sizeof(CV2))÷sizeof(CV1)
+        l*sizeof(CV1) == length(a)*sizeof(CV2) || throw(ArgumentError("sizes are incommensurate"))
+        reshape(reinterpret(CV, a), (l,))
     end
-    throw(ArgumentError("result shape not specified"))
-end
+    function reinterpretc(::Type{CV1}, a::AbstractArray{CV2}) where {CV1<:Colorant,CV2<:Colorant}
+        CV = ccolor(CV1, CV2)
+        if samesize(CV, CV2)
+            return reshape(reinterpret(CV, a), size(a))
+        end
+        throw(ArgumentError("result shape not specified"))
+    end
 
-## Color->T
-function reinterpretc(::Type{T}, a::AbstractArray{CV}) where {T<:Number,CV<:Colorant}
-    if samesize(T, CV)
-        return reinterpret(T, a)
+    # Color->T
+    function reinterpretc(::Type{T}, a::AbstractArray{CV}) where {T<:Number,CV<:Colorant}
+        if samesize(T, CV)
+            return reinterpret(T, a)
+        end
+        axs = axes(a)
+        if sizeof(CV) == sizeof(T)*_len(CV)
+            return reinterpret(T, reshape(a, Base.OneTo(1), axs...))
+        end
+        throw(ArgumentError("result shape not specified"))
     end
-    axs = axes(a)
-    if sizeof(CV) == sizeof(T)*_len(CV)
-        return reinterpret(T, reshape(a, Base.OneTo(1), axs...))
-    end
-    throw(ArgumentError("result shape not specified"))
-end
-reinterpretc(::Type{T}, a::AbstractArray{CV,0}) where {T<:Number,CV<:Colorant} =
-    reinterpret(T, reshape(a, 1))
+    reinterpretc(::Type{T}, a::AbstractArray{CV,0}) where {T<:Number,CV<:Colorant} =
+        reinterpret(T, reshape(a, 1))
 
-_len(::Type{C}) where {C} = _len(C, eltype(C))
-_len(::Type{C}, ::Type{Any}) where {C} = error("indeterminate type")
-_len(::Type{C}, ::Type{T}) where {C,T} = sizeof(C) ÷ sizeof(T)
+    _len(::Type{C}) where {C} = _len(C, eltype(C))
+    _len(::Type{C}, ::Type{Any}) where {C} = error("indeterminate type")
+    _len(::Type{C}, ::Type{T}) where {C,T} = sizeof(C) ÷ sizeof(T)
 
-## T->Color
-# We have to distinguish two forms of call:
-#   form 1: reinterpretc(RGB{N0f8}, img)
-#   form 2: reinterpretc(RGB, img)
-function reinterpretc(CV::Type{<:Colorant}, a::AbstractArray{T}) where T<:Number # {CV<:Colorant,T<:Number}
-    @noinline throwdm(C::Type, ind1) =
-        throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))
-    CVT = ccolor_number(CV, T)
-    if samesize(CVT, T)
-        return reinterpret(CVT, a)
+    ## T->Color
+    # We have to distinguish two forms of call:
+    #   form 1: reinterpretc(RGB{N0f8}, img)
+    #   form 2: reinterpretc(RGB, img)
+    function reinterpretc(CV::Type{<:Colorant}, a::AbstractArray{T}) where T<:Number # {CV<:Colorant,T<:Number}
+        @noinline throwdm(C::Type, ind1) =
+            throw(DimensionMismatch("indices $ind1 are not consistent with color type $C"))
+        CVT = ccolor_number(CV, T)
+        if samesize(CVT, T)
+            return reinterpret(CVT, a)
+        end
+        axs = axes(a)
+        if axs[1] == Base.OneTo(sizeof(CVT) ÷ sizeof(eltype(CVT)))
+            return reshape(reinterpret(CVT, a), tail(axs))
+        end
+        throwdm(CV, axs[1])
     end
-    axs = axes(a)
-    if axs[1] == Base.OneTo(sizeof(CVT) ÷ sizeof(eltype(CVT)))
-        return reshape(reinterpret(CVT, a), tail(axs))
-    end
-    throwdm(CV, axs[1])
 end
 
 # ccolor_number converts form 2 calls to form 1 calls
-ccolor_number(::Type{CV}, ::Type{T}) where {CV<:Colorant,T<:Number} =
+ccolor_number(::Type{T}, ::Any) where T<:Number = T
+ccolor_number(::Type{CV}, ::Type{T}) where {CV<:Colorant,T} =
     ccolor_number(CV, eltype(CV), T)
-ccolor_number(::Type{CV}, ::Type{CVT}, ::Type{T}) where {CV,CVT<:Number,T} = CV # form 1
+ccolor_number(::Type{CV}, ::Type{CVT}, ::Type{T}) where {CV,CVT<:Number,T} = CV  # form 1
 ccolor_number(::Type{CV}, ::Type{Any}, ::Type{T}) where {CV<:Colorant,T} = CV{T} # form 2
 
 # for docstrings in the operations below

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -407,7 +407,7 @@ end
         @test @inferred(axes(v)) == (IdentityUnitRange(-1:1), IdentityUnitRange(-2:2))
         @test @inferred(v[0,0]) === RGB(a[1,0,0], a[2,0,0], a[3,0,0])
         a = OffsetArray(rand(3, 3, 5), 0:2, -1:1, -2:2)
-        @test_throws DimensionMismatch colorview(RGB, a)
+        @test_throws (VERSION >= v"1.6.0-DEV.1083" ? ArgumentError : DimensionMismatch) colorview(RGB, a)
     end
 end
 

--- a/test/convert_reinterpret.jl
+++ b/test/convert_reinterpret.jl
@@ -129,9 +129,9 @@ using Test, Random
 
     # indeterminate type tests
     a = Array{RGB{AbstractFloat}}(undef, 3)
-    @test_throws ErrorException reinterpretc(Float64, a)
+    @test_throws Union{ArgumentError,ErrorException} reinterpretc(Float64, a)
     a = Vector{RGB}(undef, 3)
-    @test_throws ErrorException reinterpretc(Float64, a)
+    @test_throws Union{ArgumentError,ErrorException} reinterpretc(Float64, a)
 
     # Invalid conversions
     a = rand(UInt8, 4,5)

--- a/test/show.jl
+++ b/test/show.jl
@@ -6,6 +6,9 @@ else
     sumsz(img) = ""
 end
 
+const rrstr = VERSION >= v"1.6.0-DEV.1083" ? "reshape, " : ""
+rrdim(n) = VERSION >= v"1.6.0-DEV.1083" ? n-1 : n
+
 # N0f8 is shown as either N0f8 or Normed{UInt8, 8}
 # RGB is shown as ColorTypes.RGB or RGB
 function typestring(::Type{T}) where T
@@ -22,13 +25,15 @@ RGB_str = typestring(RGB)
     v = view(rgb32, 2:3, :)
     @test summary(v) == "2×5 view(::Array{RGB{Float32},2}, 2:3, :) with eltype $(RGB_str){Float32}"
     a = channelview(rgb32)
-    @test summary(a) == "3×3×5 reinterpret(Float32, ::Array{RGB{Float32},3})"
+    @test summary(a) == (VERSION >= v"1.6.0-DEV.1083" ? "3×3×5 reinterpret(reshape, Float32, ::Array{RGB{Float32},2}) with eltype Float32" :
+                                                        "3×3×5 reinterpret(Float32, ::Array{RGB{Float32},3})")
     num64 = rand(3,5)
     b = colorview(RGB, num64)
-    @test summary(b) == "5-element reshape(reinterpret(RGB{Float64}, ::$(typeof(num64))), 5) with eltype $(RGB_str){Float64}"
+    @test summary(b) == (VERSION >= v"1.6.0-DEV.1083" ? "5-element reinterpret(reshape, RGB{Float64}, ::$(typeof(num64))) with eltype $(RGB_str){Float64}" :
+                                                        "5-element reshape(reinterpret(RGB{Float64}, ::$(typeof(num64))), 5) with eltype $(RGB_str){Float64}")
     rgb8 = rand(RGB{N0f8}, 3, 5)
     c = rawview(channelview(rgb8))
-    @test summary(c) == "3×3×5 rawview(reinterpret(N0f8, ::Array{RGB{N0f8},3})) with eltype UInt8"
+    @test summary(c) == "3×3×5 rawview(reinterpret($(rrstr)N0f8, ::Array{RGB{N0f8},$(rrdim(3))})) with eltype UInt8"
     @test summary(rgb8) == "3×5 Array{RGB{N0f8},2} with eltype $(RGB_str){$(N0f8_str)}"
     rand8 = rand(UInt8, 3, 5)
     d = normedview(PermutedDimsArray(rand8, (2,1)))
@@ -39,14 +44,15 @@ RGB_str = typestring(RGB)
     f = PermutedDimsArray(normedview(N0f16, rand16), (2,1))
     @test summary(f) == "5×3 PermutedDimsArray(reinterpret(N0f16, ::$(typeof(rand16))), (2, 1)) with eltype $(N0f16_str)"
     g = channelview(rgb8)
-    @test summary(g) == "3×3×5 reinterpret(N0f8, ::Array{RGB{N0f8},3})"
+    etstr = VERSION >= v"1.6.0-DEV.1083" ? " with eltype N0f8" : ""
+    @test summary(g) == "3×3×5 reinterpret($(rrstr)N0f8, ::Array{RGB{N0f8},$(rrdim(3))})$etstr"
     h = OffsetArray(rgb8, -1:1, -2:2)
     @test summary(h) == "$(sumsz(h))OffsetArray(::Array{RGB{N0f8},2}, -1:1, -2:2) with eltype $(RGB_str){$(N0f8_str)} with indices -1:1×-2:2"
     i = channelview(h)
-    @test summary(i) == "$(sumsz(i))reinterpret(N0f8, OffsetArray(::Array{RGB{N0f8},3}, 1:1, -1:1, -2:2)) with indices 1:3×-1:1×-2:2"
+    @test summary(i) == "$(sumsz(i))reinterpret($(rrstr)N0f8, OffsetArray(::Array{RGB{N0f8},$(rrdim(3))}, 1:1, -1:1, -2:2)) with indices 1:3×-1:1×-2:2"
     c = channelview(rand(RGB{N0f8}, 2))
     o = OffsetArray(c, -1:1, 0:1)
-    @test summary(o) == "$(sumsz(o))OffsetArray(reinterpret(N0f8, ::Array{RGB{N0f8},2}), -1:1, 0:1) with eltype $(N0f8_str) with indices -1:1×0:1"
+    @test summary(o) == "$(sumsz(o))OffsetArray(reinterpret($(rrstr)N0f8, ::Array{RGB{N0f8},$(rrdim(2))}), -1:1, 0:1) with eltype $(N0f8_str) with indices -1:1×0:1"
     # Issue #45
     a = collect(tuple())
     @test summary(a) == "0-element $(typeof(a))"


### PR DESCRIPTION
When available, this switches to using Julia 1.6's new `reinterpret(reshape, T, A)` for our `colorview`/`channelview` functionality. As documented in #142, this essentially puts to rest the performance problems we've had since Julia 1.0 with `ReinterpretArray`.

The tests will still not quite pass on nightly due to `show` failures, but I plan to fix that in a separate PR.

Closes #142