### PR TITLE
Fix breakages on OffsetArrays 1.3.1

### DIFF
--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -36,7 +36,7 @@ end
                  Gray.(N0f8.(A)),
                  Gray.(N0f16.(A)) )
         imgo = OffsetArray(img, -2, -1)
-        s = @inferred(convert(OffsetArray{Gray{Float32},2,Array{Gray{Float32}}},imgo))
+        s = @inferred(convert(OffsetArray{Gray{Float32},2,Matrix{Gray{Float32}}},imgo))
         @test eltype(s) == Gray{Float32}
         @test s isa OffsetArray{Gray{Float32},2,Array{Gray{Float32},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
@@ -47,7 +47,7 @@ end
                  Gray.(N0f8.(A)),
                  Gray.(N0f16.(A)) )
         imgo = OffsetArray(img, -2, -1)
-        s = @inferred(convert(OffsetArray{Gray{N0f8},2,Array{Gray{N0f8}}},imgo))
+        s = @inferred(convert(OffsetArray{Gray{N0f8},2,Matrix{Gray{N0f8}}},imgo))
         @test eltype(s) == Gray{N0f8}
         @test s isa OffsetArray{Gray{N0f8},2,Array{Gray{N0f8},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
@@ -58,7 +58,7 @@ end
                  Gray.(N0f8.(A)),
                  Gray.(N0f16.(A)) )
         imgo = OffsetArray(img, -2, -1)
-        s = @inferred(convert(OffsetArray{Gray{N0f16},2,Array{Gray{N0f16}}},imgo))
+        s = @inferred(convert(OffsetArray{Gray{N0f16},2,Matrix{Gray{N0f16}}},imgo))
         @test eltype(s) == Gray{N0f16}
         @test s isa OffsetArray{Gray{N0f16},2,Array{Gray{N0f16},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
@@ -74,7 +74,7 @@ end
                  n2f14.(A),
                  n0f16.(A))
         imgo = OffsetArray(img, -2, -1)
-        s = @inferred(convert(OffsetArray{RGB{N0f8},2,Array{RGB{N0f8}}},imgo))
+        s = @inferred(convert(OffsetArray{RGB{N0f8},2,Matrix{RGB{N0f8}}},imgo))
         @test eltype(s) == RGB{N0f8}
         @test s isa OffsetArray{RGB{N0f8},2,Array{RGB{N0f8},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s
@@ -89,7 +89,7 @@ end
                  n2f14.(A),
                  n0f16.(A))
         imgo = OffsetArray(img, -2, -1)
-        s = @inferred(convert(OffsetArray{RGB{Float32},2,Array{RGB{Float32}}},imgo))
+        s = @inferred(convert(OffsetArray{RGB{Float32},2,Matrix{RGB{Float32}}},imgo))
         @test eltype(s) == RGB{Float32}
         @test s isa OffsetArray{RGB{Float32},2,Array{RGB{Float32},2}}
         @test permutedims(permutedims(s,(2,1)),(2,1)) == s


### PR DESCRIPTION
These were just in deprecated tests, but I think it makes sense to keep these a little longer.