### PR TITLE
[CI] fix FFTW version for old Julia versions

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -40,7 +40,13 @@ jobs:
 
       - name: "Compat fix for Julia < v1.3.0"
         if: ${{ matrix.julia-version == '1.0' }}
-        run: julia --project=. --startup=no --color=yes -e 'using Pkg; pkg"add FFTW@1.1 AbstractFFTs@0.5"'
+        run: |
+          using Pkg
+          Pkg.add([
+            PackageSpec(name="FFTW", version="1.1"),
+            PackageSpec(name="AbstractFFTs", version="0.5")
+          ])
+        shell: julia --project=. --startup=no --color=yes {0}
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master
 

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -38,6 +38,15 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
 
+      - name: "Compat fix for Julia < v1.3.0"
+        if: ${{ julia-version }} == '1.0'
+        run: |
+          using Pkg
+          Pkg.add([
+            PackageSpec(name="FFTW", version="1.1")
+            PackageSpec(name="AbstractFFTs", version="0.5")
+            ])
+        shell: julia --project=. --startup=no --color=yes {0}
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master
 

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: "Compat fix for Julia < v1.3.0"
-        if: ${{ ${{ julia-version}} == '1.0' }}
+        if: ${{ matrix.julia-version == '1.0' }}
         run: julia --project=. --startup=no --color=yes -e 'using Pkg; pkg"add FFTW@1.1 AbstractFFTs@0.5"'
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -40,13 +40,7 @@ jobs:
 
       - name: "Compat fix for Julia < v1.3.0"
         if: ${{ julia-version }} == '1.0'
-        run: |
-          using Pkg
-          Pkg.add([
-            PackageSpec(name="FFTW", version="1.1")
-            PackageSpec(name="AbstractFFTs", version="0.5")
-            ])
-        shell: julia --project=. --startup=no --color=yes {0}
+        run: julia --project=. --startup=no --color=yes -e 'using Pkg; pkg"add FFTW@1.1 AbstractFFTs@0.5"'
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master
 

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: "Compat fix for Julia < v1.3.0"
-        if: ${{ julia-version == '1.0' }}
+        if: ${{ ${{ julia-version}} == '1.0' }}
         run: julia --project=. --startup=no --color=yes -e 'using Pkg; pkg"add FFTW@1.1 AbstractFFTs@0.5"'
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master

--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: "Compat fix for Julia < v1.3.0"
-        if: ${{ julia-version }} == '1.0'
+        if: ${{ julia-version == '1.0' }}
         run: julia --project=. --startup=no --color=yes -e 'using Pkg; pkg"add FFTW@1.1 AbstractFFTs@0.5"'
       - name: "Unit Test"
         uses: julia-actions/julia-runtest@master


### PR DESCRIPTION
Pkg in old Julia versions are not smart enough to find a compatible path out, so here we manually tell them the right version to make sure CI successfully runs for Julia-1.0.