### PR TITLE
use Aqua for meta test

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -43,8 +43,7 @@ jobs:
         run: |
           using Pkg
           Pkg.add([
-            PackageSpec(name="FFTW", version="1.1"),
-            PackageSpec(name="AbstractFFTs", version="0.5")
+            PackageSpec(name="AbstractFFTs", version="0.5"),
           ])
         shell: julia --project=. --startup=no --color=yes {0}
       - name: "Unit Test"

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 AbstractFFTs = "0.4, 0.5, 1.0"
+ColorVectorSpace = "0.8"
 Colors = "0.9, 0.10, 0.11, 0.12"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 Graphics = "0.4, 1.0"
@@ -26,6 +27,7 @@ Reexport = "0.2, 1.0"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -37,4 +39,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorVectorSpace", "Documenter", "FFTW", "ImageInTerminal", "ImageMagick", "Random", "ReferenceTests", "Statistics", "Test"]
+test = ["Aqua", "ColorVectorSpace", "Documenter", "FFTW", "ImageInTerminal", "ImageMagick", "Random", "ReferenceTests", "Statistics", "Test"]

--- a/src/colorchannels.jl
+++ b/src/colorchannels.jl
@@ -121,12 +121,12 @@ _ccolorview(::Type{C}, A::RRArray{T,C}) where {C<:Colorant,T<:Number} =
 if VERSION >= v"1.6.0-DEV.1083"
     _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,false}) where {C<:RGB,T<:Number,M,AA} =
         reshape(parent(A), Base.tail(axes(parent(A))))
-    _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,true}) where {C<:RGB,T<:Number,M,AA} =
-        parent(A)
+    # _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,true}) where {C<:RGB,T<:Number,M,AA} =
+    #     parent(A)
     _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,false}) where {C<:Color,T<:Number,M,AA} =
         reshape(parent(A), Base.tail(axes(parent(A))))
-    _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,true}) where {C<:Color,T<:Number,M,AA} =
-        parent(A)
+    # _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C,AA,true}) where {C<:Color,T<:Number,M,AA} =
+    #     parent(A)
 else
     _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:AbstractGray,T<:Number,M} =
         parent(A)
@@ -135,8 +135,8 @@ else
     _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:Color,T<:Number,M} =
         reshape(parent(A), Base.tail(axes(parent(A))))
     end
-_ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:AbstractRGB,T<:Number,M} =
-    _colorview_reorder(C, A)
+# _ccolorview(::Type{C}, A::Base.ReinterpretArray{T,M,C}) where {C<:AbstractRGB,T<:Number,M} =
+#     _colorview_reorder(C, A)
 _ccolorview(::Type{C}, A::AbstractArray{T}) where {C<:Colorant,T<:Number} =
     __ccolorview(C, A)  # necessary to avoid ambiguities from dispatch on eltype
 __ccolorview(::Type{C}, A::AbstractArray{T}) where {T<:Number,C<:RGB{T}} = reinterpretc(C, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,20 @@
 module ImageCoreTests
 
-using ImageCore, Test, ReferenceTests
+using ImageCore
+using Test, ReferenceTests
+using Aqua, Documenter # for meta quality checks
 
-# If we've run the tests previously, there might be ambiguities from other packages
-if :StatsBase ∉ map(x->Symbol(string(x)), values(Base.loaded_modules))
-    @test isempty(detect_ambiguities(ImageCore, Base, Core))
+@testset "Project meta quality checks" begin
+    # Not checking compat section for test-only dependencies
+    Aqua.test_all(ImageCore;
+                  project_extras=true,
+                  deps_compat=true,
+                  stale_deps=true,
+                  project_toml_formatting=true,
+                  unbound_args=false, # FIXME: it fails when this is true
+    )
+    DocMeta.setdocmeta!(ImageCore, :DocTestSetup, :(using ImageCore); recursive=true)
 end
-
-using Documenter
-DocMeta.setdocmeta!(ImageCore, :DocTestSetup, :(using ImageCore); recursive=true)
 
 # ReferenceTests uses ImageInTerminal as a default image rendering backend, we need to
 # temporarily disable it when we do doctest.


### PR DESCRIPTION
And also fixes the ambiguity issue, which is separated from #157

The compat for CSV 0.8 is for test purposes.