### PR TITLE
Streamline the ambiguity test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,12 +6,7 @@ using Aqua, Documenter # for meta quality checks
 
 @testset "Project meta quality checks" begin
     # Not checking compat section for test-only dependencies
-
-    ambiguity_exclude_list = [
-        # https://github.com/JuliaDiff/ChainRulesCore.jl/pull/367#issuecomment-869071000
-        Base.:(==),
-    ]
-    Aqua.test_ambiguities([ImageCore, Base, Core], exclude=ambiguity_exclude_list)
+    Aqua.test_ambiguities(ImageCore)
     Aqua.test_all(ImageCore;
                   ambiguities=false,
                   project_extras=true,


### PR DESCRIPTION
Recent Julia versions have gotten much better about detecting
ambiguities, and in particular in distinguishing package-induced
ambiguities from those in dependencies. We should leverage those
mechanisms in our tests.

Noticed from PkgEval failures on the [dashboard](https://github.com/JuliaImages/juliaimages.github.io/blob/source/DASHBOARD.md)