### PR TITLE
unwrap rawview(::channelview) with one reshape reinterpret

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -115,6 +115,11 @@ rawview(a::AbstractArray{T}) where {T<:FixedPoint} = mappedarray(reinterpret, y-
 rawview(a::Array{T}) where {T<:FixedPoint} = reinterpret(FixedPointNumbers.rawtype(T), a)
 rawview(a::AbstractArray{T}) where {T<:Real} = a
 
+if VERSION >= v"1.6.0-DEV.1083"
+    # does not use the slow `mappedarray` fallback for, typically, `rawview(channelview(img))`
+    rawview(a::Base.ReinterpretArray{T}) where {T<:FixedPoint} = reinterpret(reshape, FixedPointNumbers.rawtype(T), parent(a))
+end
+
 """
     normedview([T], img::AbstractArray{Unsigned})
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -35,8 +35,11 @@ RGB_str = typestring(RGB)
     rgb8 = rand(RGB{N0f8}, 3, 5)
     c = rawview(channelview(rgb8))
     str = summary(c)
-    @test occursin("3×3×5 rawview(reinterpret($(rrstr)", str) && occursin("N0f8", str) &&
-          occursin("::Array{RGB{N0f8},$(rrdim(3))}", str) && occursin("with eltype UInt8", str)
+    if VERSION >= v"1.6.0-DEV.1083"
+        @test str == "3×3×5 reinterpret(reshape, UInt8, ::Array{RGB{N0f8},2}) with eltype UInt8"
+    else
+        @test str == "3×3×5 rawview(reinterpret(N0f8, ::Array{RGB{N0f8},3})) with eltype UInt8"
+    end
     @test summary(rgb8) == "3×5 Array{RGB{N0f8},2} with eltype $(RGB_str){$(N0f8_str)}"
     rand8 = rand(UInt8, 3, 5)
     d = normedview(PermutedDimsArray(rand8, (2,1)))

--- a/test/views.jl
+++ b/test/views.jl
@@ -18,6 +18,19 @@ using PaddedViews: filltype
     v[2,2] = 0x0f
     @test a[2,2].i == 0x0f
     @test rawview(v) === v
+
+    if VERSION >= v"1.6.0-DEV.1083"
+        @testset "rawview(::AbstractArray)" begin
+            a = rand(RGB{N0f8}, 5, 5)
+            X1 = rawview(channelview(a))
+            X2 = rawview(collect(channelview(a)))
+            @test !isa(parent(X1), Base.ReinterpretArray)
+            @test typeof(X1) != typeof(X2)
+            @test axes(X1) == axes(X2)
+            @test eltype(X1) == eltype(X2)
+            @test X1 == X2
+        end
+    end
 end
 
 @testset "normedview" begin


### PR DESCRIPTION
This does not fix #174 but could be potentially a good change by eliminating one mapped array wrapper.