### PR TITLE
Restrict clamp01 to gray & RGB

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -11,8 +11,8 @@ channel separately.
 See also: [`clamp01!`](@ref), [`clamp01nan`](@ref).
 """
 clamp01(x::Union{N0f8,N0f16}) = x
-clamp01(x::Number) = clamp(x, zero(x), oneunit(x))
-clamp01(c::Colorant) = mapc(clamp01, c)
+clamp01(x::NumberLike) = clamp(x, zero(x), oneunit(x))
+clamp01(c::Union{TransparentGray,AbstractRGB,TransparentRGB}) = mapc(clamp01, c)
 
 """
     clamp01!(array::AbstractArray)
@@ -35,8 +35,8 @@ Similar to `clamp01`, except that any `NaN` values are changed to 0.
 See also: [`clamp01nan!`](@ref), [`clamp01`](@ref).
 """
 clamp01nan(x) = clamp01(x)
-clamp01nan(x::AbstractFloat) = ifelse(isnan(x), zero(x), clamp01(x))
-clamp01nan(c::Colorant) = mapc(clamp01nan, c)
+clamp01nan(x::Union{AbstractFloat,AbstractGray{<:AbstractFloat}}) = ifelse(isnan(x), zero(x), clamp01(x))
+clamp01nan(c::Union{TransparentGray,AbstractRGB,TransparentRGB}) = mapc(clamp01nan, c)
 
 """
     clamp01nan!(array::AbstractArray)


### PR DESCRIPTION
The 0-to-1 colorscale does not have meaning for colors like HSV,
so supporting arbitrary colorants seems wrong.

I noticed this while working on https://github.com/JuliaImages/FluorophoreColors.jl/pull/4. We might not want to merge this until we decide to make a push for the next breaking release.