### PR TITLE
Support zeroarray for heterogeneous axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -29,7 +29,7 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
@@ -40,4 +40,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ColorVectorSpace", "Documenter", "FFTW", "ImageInTerminal", "ImageMagick", "Random", "ReferenceTests", "Statistics", "Test"]
+test = ["Aqua", "BlockArrays", "Documenter", "FFTW", "ImageInTerminal", "ImageMagick", "Random", "ReferenceTests", "Statistics", "Test"]

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -103,7 +103,7 @@ struct ZeroArray{T,N,R<:AbstractUnitRange} <: AbstractArray{T,N}
 end
 
 ZeroArrayPromise{T}(inds::NTuple{N,R}) where {T,N,R<:AbstractUnitRange} = ZeroArray{T,N,R}(inds)
-ZeroArrayPromise{T}(inds::NTuple{N,AbstractUnitRange}) where {T,N} = ZeroArray{T}(promote(inds...)...)
+ZeroArrayPromise{T}(inds::NTuple{N,AbstractUnitRange}) where {T,N} = ZeroArrayPromise{T}(promote(inds...))
 Base.eltype(::Type{ZeroArrayPromise{T}}) where {T} = T
 
 Base.axes(A::ZeroArray) = A.inds

--- a/src/stackedviews.jl
+++ b/src/stackedviews.jl
@@ -103,6 +103,7 @@ struct ZeroArray{T,N,R<:AbstractUnitRange} <: AbstractArray{T,N}
 end
 
 ZeroArrayPromise{T}(inds::NTuple{N,R}) where {T,N,R<:AbstractUnitRange} = ZeroArray{T,N,R}(inds)
+ZeroArrayPromise{T}(inds::NTuple{N,AbstractUnitRange}) where {T,N} = ZeroArray{T}(promote(inds...)...)
 Base.eltype(::Type{ZeroArrayPromise{T}}) where {T} = T
 
 Base.axes(A::ZeroArray) = A.inds

--- a/test/colorchannels.jl
+++ b/test/colorchannels.jl
@@ -1,5 +1,6 @@
 using Colors, ImageCore, OffsetArrays, FixedPointNumbers, Test
 using OffsetArrays: IdentityUnitRange
+using BlockArrays
 
 # backward-compatibility to ColorTypes < v0.9 or Colors < v0.11
 using ImageCore: XRGB, RGBX
@@ -408,6 +409,20 @@ end
         @test @inferred(v[0,0]) === RGB(a[1,0,0], a[2,0,0], a[3,0,0])
         a = OffsetArray(rand(3, 3, 5), 0:2, -1:1, -2:2)
         @test_throws (VERSION >= v"1.6.0-DEV.1083" ? ArgumentError : DimensionMismatch) colorview(RGB, a)
+    end
+
+    @testset "Custom/divergent axis types" begin
+        img1 = rand(5, 4, 2)
+        img2_2 = mortar(reshape([rand(5, 4, 1), rand(5, 4, 1)], 1, 1, 2))
+        img2_all = mortar(reshape([rand(5, 4, 1), rand(5, 4, 1), rand(5, 4, 1)], 1, 1, 3))
+        img2_odd = img2_all[:,:,1:2:end]
+        for img2 in (img2_2, img2_odd)
+            for imgrgb in (colorview(RGB, img1, img2, zeroarray),
+                        colorview(RGB, img2, img1, zeroarray))
+                @test eltype(imgrgb) === RGB{Float64}
+                @test size(imgrgb) == size(img1)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Previously `ZeroArrayPromise` required homogeneous axes,
this supports promotion prior to construction.
The test requires BlockArrays 0.16.~17~18 (specifically
https://github.com/JuliaArrays/BlockArrays.jl/pull/213)
but it's not a dependency of the package, so let's just
trust in the lack of conflicts.