### PR TITLE
latency: disable heavy precompilation

### DIFF
--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -170,9 +170,9 @@ function Base.transpose(a::AbstractVector{C}) where C<:Colorant
     out
 end
 
-if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
-    include("precompile.jl")
-    _precompile_()
-end
+# if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
+#     include("precompile.jl")
+#     _precompile_()
+# end
 
 end ## module


### PR DESCRIPTION
Due to the same spirit to https://github.com/JuliaGraphics/ColorTypes.jl/pull/270 but I'm not very sure of it. Probably we'd like to limit ourselves to a smaller set of precompilation statements?

```julia
julia> @time using ImageCore # precompiled
# master: 0.887365 seconds (1.90 M allocations: 147.668 MiB, 4.39% gc time, 1.76% compilation time)
# PR: 0.538029 seconds (1.11 M allocations: 81.958 MiB, 2.86% gc time, 2.85% compilation time)
```

recompilation:

```julia
julia> @time using ImageCore
[ Info: Precompiling ImageCore [a09fc81d-aa75-5fe9-8630-4744c3626534]
# master:  17.931215 seconds (1.92 M allocations: 148.941 MiB, 0.23% gc time, 0.09% compilation time)
# PR: 1.823635 seconds (1.13 M allocations: 83.243 MiB, 1.05% gc time, 0.94% compilation time)
```

