### PR TITLE
Switch to SnoopPrecompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ MosaicViews = "e94cdb99-869f-56ef-bcf0-1ae2bcbe0389"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 AbstractFFTs = "0.4, 0.5, 1.0"
@@ -25,6 +26,7 @@ MosaicViews = "0.3.3"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1.0.1"
 PaddedViews = "0.5.8"
 Reexport = "0.2, 1.0"
+SnoopPrecompile = "1"
 julia = "1"
 
 [extras]

--- a/src/ImageCore.jl
+++ b/src/ImageCore.jl
@@ -192,7 +192,6 @@ end
 
 if VERSION >= v"1.4.2" # work around https://github.com/JuliaLang/julia/issues/34121
     include("precompile.jl")
-    _precompile_()
 end
 
 end ## module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,109 +1,103 @@
-macro warnpcfail(ex::Expr)
-    modl = __module__
-    file = __source__.file === nothing ? "?" : String(__source__.file)
-    line = __source__.line
-    quote
-        $(esc(ex)) || @warn """precompile directive
-     $($(Expr(:quote, ex)))
- failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+using SnoopPrecompile
+
+let
+@precompile_setup begin
+    function pcarray(f::F, ::Type{A}, sz) where {F,A}
+        a = f(A(undef, sz))
+        fill!(a, zero(eltype(a)))
+        return first(a)
     end
-end
+    function pcm(a1, a2; fillvalue = zero(eltype(a1)))
+        v = mosaic(a1, a2; fillvalue=fillvalue)
+        return first(v)
+    end
+    function pcmv(a; fillvalue = zero(eltype(a)))
+        v = mosaicview(a; fillvalue=fillvalue)
+        return first(v)
+    end
 
-function pcarray(f::F, ::Type{A}, sz) where {F,A}
-    a = f(A(undef, sz))
-    fill!(a, zero(eltype(a)))
-    return first(a)
-end
-function pcm(a1, a2; fillvalue = zero(eltype(a1)))
-    v = mosaic(a1, a2; fillvalue=fillvalue)
-    return first(v)
-end
-function pcmv(a; fillvalue = zero(eltype(a)))
-    v = mosaicview(a; fillvalue=fillvalue)
-    return first(v)
-end
-
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
     pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
     cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
     dims  = (1, 2, 3, 4)
     szs   = ((2,), (2, 2), (2, 2, 2), (2, 2, 2, 2))
-
-    for T in eltypes
-        @warnpcfail precompile(clamp01, (T,))
-        @warnpcfail precompile(clamp01nan, (T,))
-        @warnpcfail precompile(scaleminmax, (T, T))
-        @warnpcfail precompile(scalesigned, (T,))
-        @warnpcfail precompile(scalesigned, (T,T,T))
-        for C in pctypes
-            @warnpcfail precompile(clamp01, (C{T},))
-            @warnpcfail precompile(clamp01nan, (C{T},))
-            @warnpcfail precompile(colorsigned, (C{T},C{T}))
-        end
-    end
-    for C in cctypes
-        @warnpcfail precompile(clamp01, (C,))
-        @warnpcfail precompile(clamp01nan, (C,))
-        @warnpcfail precompile(colorsigned, (C,C))
-    end
-    # For the arrays, it's better to make them and exercise them so we get the getindex/setindex!
-    # methods precompiled too.
-    for sz in szs
+    @precompile_all_calls begin
         for T in eltypes
-            T <: FixedPoint || continue
-            pcarray(rawview, Array{T,length(sz)}, sz)
-        end
-        pcarray(normedview, Array{UInt8,length(sz)}, sz)
-        pcarray(a->normedview(N0f8, a),  Array{UInt8, length(sz)}, sz)
-        pcarray(a->normedview(N0f16, a), Array{UInt16,length(sz)}, sz)
-    end
-    for sz in szs
-        for T in eltypes
+            clamp01(zero(T))
+            clamp01nan(zero(T))
+            scaleminmax(zero(T), oneunit(T))
+            scalesigned(oneunit(T))
+            scalesigned(zero(T), oneunit(T) / 2, oneunit(T))
             for C in pctypes
-                nc = sizeof(C{T}) ÷ sizeof(T)
-                if nc == 1
-                    pcarray(a->colorview(C,    a), Array{T,length(sz)}, sz)
-                    pcarray(a->colorview(C{T}, a), Array{T,length(sz)}, sz)
-                else
-                    pcarray(a->colorview(C,    a), Array{T,length(sz)+1}, (nc, sz...))
-                    pcarray(a->colorview(C{T}, a), Array{T,length(sz)+1}, (nc, sz...))
-                end
-                pcarray(channelview, Array{C{T},length(sz)}, sz)
-                if T<:FixedPoint
-                    R = FixedPointNumbers.rawtype(T)
+                clamp01(zero(C{T}))
+                clamp01nan(zero(C{T}))
+                colorsigned(zero(C{T}), oneunit(C{T}))
+            end
+        end
+        for C in cctypes
+            clamp01(zero(C))
+            clamp01nan(zero(C))
+            C === AGray32 && continue
+            colorsigned(zero(C), oneunit(C))
+        end
+        # For the arrays, it's better to make them and exercise them so we get the getindex/setindex!
+        # methods precompiled too.
+        for sz in szs
+            for T in eltypes
+                T <: FixedPoint || continue
+                pcarray(rawview, Array{T,length(sz)}, sz)
+            end
+            pcarray(normedview, Array{UInt8,length(sz)}, sz)
+            pcarray(a->normedview(N0f8, a),  Array{UInt8, length(sz)}, sz)
+            pcarray(a->normedview(N0f16, a), Array{UInt16,length(sz)}, sz)
+        end
+        for sz in szs
+            for T in eltypes
+                for C in pctypes
+                    nc = sizeof(C{T}) ÷ sizeof(T)
                     if nc == 1
-                        pcarray(a->colorview(C,    normedview(T, a)), Array{R,length(sz)}, sz)
-                        pcarray(a->colorview(C{T}, normedview(T, a)), Array{R,length(sz)}, sz)
+                        pcarray(a->colorview(C,    a), Array{T,length(sz)}, sz)
+                        pcarray(a->colorview(C{T}, a), Array{T,length(sz)}, sz)
                     else
-                        pcarray(a->colorview(C,    normedview(T, a)), Array{R,length(sz)+1}, (nc, sz...))
-                        pcarray(a->colorview(C{T}, normedview(T, a)), Array{R,length(sz)+1}, (nc, sz...))
+                        pcarray(a->colorview(C,    a), Array{T,length(sz)+1}, (nc, sz...))
+                        pcarray(a->colorview(C{T}, a), Array{T,length(sz)+1}, (nc, sz...))
+                    end
+                    pcarray(channelview, Array{C{T},length(sz)}, sz)
+                    if T<:FixedPoint
+                        R = FixedPointNumbers.rawtype(T)
+                        if nc == 1
+                            pcarray(a->colorview(C,    normedview(T, a)), Array{R,length(sz)}, sz)
+                            pcarray(a->colorview(C{T}, normedview(T, a)), Array{R,length(sz)}, sz)
+                        else
+                            pcarray(a->colorview(C,    normedview(T, a)), Array{R,length(sz)+1}, (nc, sz...))
+                            pcarray(a->colorview(C{T}, normedview(T, a)), Array{R,length(sz)+1}, (nc, sz...))
+                        end
                     end
                 end
             end
+            T, C = Bool, Gray
+            pcarray(a->colorview(C,    a), Array{T,length(sz)}, sz)
+            pcarray(a->colorview(C{T}, a), Array{T,length(sz)}, sz)
+            pcarray(channelview, Array{C{T},length(sz)}, sz)
         end
-        T, C = Bool, Gray
-        pcarray(a->colorview(C,    a), Array{T,length(sz)}, sz)
-        pcarray(a->colorview(C{T}, a), Array{T,length(sz)}, sz)
-        pcarray(channelview, Array{C{T},length(sz)}, sz)
-    end
-    for T in eltypes
-        a = zeros(T, (2, 2))
-        a3 = zeros(T, (2, 2, 2))
-        pcm(a, a)
-        pcmv(a3)
-        for C in (Gray, RGB, GrayA, RGBA)
-            a = zeros(C{T}, (2, 2))
-            a3 = zeros(C{T}, (2, 2, 3))
+        for T in eltypes
+            a = zeros(T, (2, 2))
+            a3 = zeros(T, (2, 2, 2))
             pcm(a, a)
             pcmv(a3)
-            if C === RGB
-                pcm(a, a; fillvalue=zero(Gray{T}))
-            elseif C === RGBA
-                pcm(a, a; fillvalue=zero(GrayA{T}))
+            for C in (Gray, RGB, GrayA, RGBA)
+                a = zeros(C{T}, (2, 2))
+                a3 = zeros(C{T}, (2, 2, 3))
+                pcm(a, a)
+                pcmv(a3)
+                if C === RGB
+                    pcm(a, a; fillvalue=zero(Gray{T}))
+                elseif C === RGBA
+                    pcm(a, a; fillvalue=zero(GrayA{T}))
+                end
             end
         end
+        pcm(zeros(Float32, 2, 2), zeros(Float64, 2, 2))  # heterogeneous
     end
-    pcm(zeros(Float32, 2, 2), zeros(Float64, 2, 2))  # heterogeneous
+end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -16,9 +16,9 @@ let
         return first(v)
     end
 
-    eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
-    pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
-    cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
+    eltypes = (N0f8, N0f16, Float32, Float64)    # eltypes of parametric colors
+    pctypes = (Gray, RGB)                        # parametric colors
+    cctypes = ()                                 # non-parametric colors (e.g., Gray24)
     dims  = (1, 2, 3, 4)
     szs   = ((2,), (2, 2), (2, 2, 2), (2, 2, 2, 2))
     @precompile_all_calls begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using Aqua, Documenter # for meta quality checks
                   ambiguities=false,
                   project_extras=true,
                   deps_compat=true,
-                  stale_deps=Base.VERSION < v"1.5", # we don't use AbstractFFTs on 1.5+
+                  stale_deps= v"1.4" <= Base.VERSION < v"1.5", # we don't use AbstractFFTs on 1.5+, SnoopPrecompile on <1.4
                   # FIXME? re-enable the `piracy` test
                   piracy=false, # Base.VERSION >= v"1.5",    # need the register_error_hint for AbstractFFTs
                   project_toml_formatting=true,


### PR DESCRIPTION
Using Julia nightly, this cuts the time required to execute the
workload in the `@precompile_all_calls` from 6.55s to 2.15s,
while also slightly reducing load time from 1.06s to 0.99s.
With no precompilation, the same workload is 18.4s.

The fact that the benefit is not even larger is surely due to compilation
of the helper functions `pcarray`, `pcm`, and `pcmv`.
(There are no relevant invalidations.)