### PR TITLE
Require CVS 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageCore"
 uuid = "a09fc81d-aa75-5fe9-8630-4744c3626534"
-version = "0.9.4"
+version = "0.10.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -16,7 +16,7 @@ SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 AbstractFFTs = "0.4, 0.5, 1.0"
-ColorVectorSpace = "0.9.7"
+ColorVectorSpace = "0.10"
 Colors = "0.12"
 FixedPointNumbers = "0.8"
 MappedArrays = "0.2, 0.3, 0.4"
@@ -33,11 +33,10 @@ BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BlockArrays", "Documenter", "FFTW", "ImageInTerminal", "ImageMagick", "Random", "ReferenceTests", "Statistics", "Test"]
+test = ["Aqua", "BlockArrays", "Documenter", "FFTW", "ImageInTerminal", "Random", "ReferenceTests", "Statistics", "Test"]


### PR DESCRIPTION
This sets the stage for the entire JuliaImages ecosystem switching
to ColorVectorSpace 0.10. We can also anticipate the removal
of ColorVectorSpace.Future.abs2 internally, so the switch to
CVS 0.11 won't require a breaking change here or elsewhere.

This is going to be an absolute mess on CI: our test `[extras]` include Sixel (via ImageInTerminal) and ReferenceTests, both of which in turn depend on ImageCore. Thus even though the package dependencies are acyclic, our test dependencies are cyclic. So it's guaranteed that CI will fail here until  those packages have their dependencies bumped.

I've removed ImageMagick as a test dependency since it doesn't seem to be used.